### PR TITLE
feat(pagination/vue): add Vue pagination example with wcs-fetch integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ coverage/
 .tsc-out/
 .vscode/
 examples/*/dist/
+packages/*/examples/**/dist/
 .claude/scheduled_tasks.lock

--- a/packages/fetch/examples/pagination/README.ja.md
+++ b/packages/fetch/examples/pagination/README.ja.md
@@ -1,0 +1,80 @@
+# ページネーション、5つの作り方
+
+[English](./README.md)
+
+同じページネーション付きリスト（**200 件・1 ページ 12 件・サーバー側に遅延あり**）を、**1 つの共通
+サーバー**に対して 5 通りに実装しました。データ・生成される DOM・スタイルは 5 つとも完全に同一で、
+変わるのはフロントエンドの作り方だけです。**5 つすべてが同一のヘッドレス `<wcs-fetch>` ノード**
+を **wc-bindable プロトコル**経由で駆動するので、取得・abort・古いレスポンスの破棄はすべて要素側に
+あり、違うのは「各パラダイムがその要素をどう購読するか（結線層）」だけです。実際のページネーション
+に必ず必要な次の 3 点を、各パラダイムがどう扱うかを横並びで比較できます。
+
+1. 現在のページを保持する
+2. ページが変わったら再取得する
+3. **古くなったリクエストを破棄する**（遅れて返ってきた前ページの結果が新しいページを上書きしないように）
+
+| デモ | アプローチ | ビルド |
+|------|-----------|--------|
+| [`state/`](./state/) | `@wcstack/state` — 宣言的な `<wcs-fetch>` + `data-wcs`、JS のつなぎコードなし | 不要（buildless） |
+| [`signals/`](./signals/) | `@wcstack/signals` — `bindNode()` で `<wcs-fetch>` を signals 化、`bindInput` で url 書き戻し | 不要（buildless）\* |
+| [`vanilla/`](./vanilla/) | 手書きの DOM + ヘッドレス `<wcs-fetch>`（`@wc-bindable/core` の `bind()` で購読） | 不要（buildless） |
+| [`react/`](./react/) | React 19 — `useState` + `<wcs-fetch>`（`@wc-bindable/react` の `useWcBindable`） | Vite |
+| [`vue/`](./vue/) | Vue 3 — Composition API + `<wcs-fetch>`（`@wc-bindable/vue` の `useWcBindable`） | Vite |
+
+\* signals はローカルビルド済みバンドルを読み込むため、先に `packages/signals` を一度ビルドしてください。
+
+## 共通サーバー
+
+[`shared/`](./shared/) に、全デモが叩く唯一のサーバーがあります。
+
+- `data.js` — 決定的に生成した 200 件のメンバー（`id` / `name` / `email` / `role` / `joinedAt`）
+- `server.js` — `createPaginationServer()` と、直接実行用の「ハブ」
+- `style.css` — 5 デモ共通の唯一のスタイルシート（だから見た目が揃う）
+
+エンドポイント：
+
+```
+GET /api/items?page=<1始まり>&limit=12
+  -> { items: [...], page, limit, total, totalPages }   （+ 約400ms の遅延）
+```
+
+`page` はサーバー側で `[1, totalPages]` にクランプされます。
+
+## 起動方法
+
+**state / signals / vanilla** は buildless で、ハブが配信します（`/` のギャラリーと `/api/items`
+も同じハブが提供）。
+
+```bash
+# signals デモ用にバンドルを一度ビルド（signals デモを見る場合のみ）
+cd packages/signals && npm install && npm run build && cd -
+
+node packages/fetch/examples/pagination/shared/server.js
+# http://localhost:3400 を開く
+```
+
+**React / Vue** は Vite を使い、各自が自分のポートでビルド・配信します（`/api/items` の契約は共通）。
+
+```bash
+cd packages/fetch/examples/pagination/react && npm install && npm run start   # http://localhost:3404
+cd packages/fetch/examples/pagination/vue   && npm install && npm run start   # http://localhost:3405
+```
+
+フレームワークの dev モード（`npm run dev`）を使う場合はハブも起動してください。Vite の dev サーバー
+が `/api` をハブにプロキシします。
+
+## 見どころ
+
+- **state** は機能のほぼ全てを HTML で表現します。`page` が変わると `url` getter が再計算され、
+  `<wcs-fetch>` が再取得して前のリクエストを自動 abort、リスト／ページャーは純粋な `data-wcs`
+  バインディング — 命令的な fetch コードは一切ありません。
+- **signals** は同じ `<wcs-fetch>` を `bindNode()` で signals 化します。要素の `value` / `loading`
+  / `error` が read signal になり、`page` から組み立てた `url` を `bindInput` で要素に書き戻すと、
+  要素が再取得して前リクエストを自動 abort（switchMap 相当のキャンセル／リスタートは要素側）。
+  `resource()` も手書きの `AbortController` も要りません。
+- **vanilla** は同じ `<wcs-fetch>` を最小構成で消費します。`@wc-bindable/core` の `bind()` が要素の
+  `value` / `loading` / `error` をプレーンな `state` に流し込み、あとは手書きの DOM 更新だけ。
+  `AbortController` も loading の状態管理も要素が持つので、書くのは描画だけです。
+- **React / Vue** は同じ `<wcs-fetch>` を各フレームワークのアダプタ（`useWcBindable`）で購読します。
+  `page` から URL を組み立てて要素に渡すだけで、再取得・abort・stale 対策は要素側が担います。
+  `useEffect` / `watch` での `AbortController` 手回しはもう要りません。

--- a/packages/fetch/examples/pagination/README.md
+++ b/packages/fetch/examples/pagination/README.md
@@ -1,0 +1,82 @@
+# Pagination, five ways
+
+[日本語版](./README.ja.md)
+
+The same paginated list — **200 members, 12 per page, with server-side latency** — built five
+times against **one shared server**. The dataset, the rendered markup and the styling are
+identical across all five; only the front-end approach changes. **All five drive the
+same headless `<wcs-fetch>` node** through the **wc-bindable protocol** (each via a different
+binding layer), so the fetch, the abort and the stale-response protection live in the element,
+and the only thing that varies is how each paradigm subscribes to it. It's a side-by-side look
+at how each handles three things every real paginated list needs:
+
+1. holding the current page,
+2. re-fetching when the page changes, and
+3. **cancelling a superseded request** so a slow earlier page can't overwrite a newer one.
+
+| Demo | Approach | Build step |
+|------|----------|------------|
+| [`state/`](./state/) | `@wcstack/state` — declarative `<wcs-fetch>` + `data-wcs`, no JS glue | none (buildless) |
+| [`signals/`](./signals/) | `@wcstack/signals` — `bindNode()` adapts `<wcs-fetch>` into signals, `bindInput` writes the url | none (buildless)\* |
+| [`vanilla/`](./vanilla/) | Hand-built DOM + headless `<wcs-fetch>` (bound with `@wc-bindable/core`'s `bind()`) | none (buildless) |
+| [`react/`](./react/) | React 19 — `useState` + `<wcs-fetch>` (`@wc-bindable/react`'s `useWcBindable`) | Vite |
+| [`vue/`](./vue/) | Vue 3 — Composition API + `<wcs-fetch>` (`@wc-bindable/vue`'s `useWcBindable`) | Vite |
+
+\* signals imports the locally-built bundle; build `packages/signals` once first.
+
+## The shared server
+
+[`shared/`](./shared/) holds the one server every demo talks to:
+
+- `data.js` — 200 deterministically-generated members (`id`, `name`, `email`, `role`, `joinedAt`).
+- `server.js` — `createPaginationServer()` plus a direct-run "hub".
+- `style.css` — the single stylesheet all five demos use, so they look identical.
+
+The endpoint:
+
+```
+GET /api/items?page=<1-based>&limit=12
+  -> { items: [...], page, limit, total, totalPages }   (+ ~400ms latency)
+```
+
+`page` is clamped server-side to `[1, totalPages]`.
+
+## Running
+
+**state / signals / vanilla** are buildless and served by the hub (this also serves the gallery
+at `/` and the `/api/items` endpoint):
+
+```bash
+# build signals once so its bundle can be served (only needed for the signals demo)
+cd packages/signals && npm install && npm run build && cd -
+
+node packages/fetch/examples/pagination/shared/server.js
+# open http://localhost:3400
+```
+
+**React / Vue** use Vite — each builds and serves itself on its own port, reusing the same
+`/api/items` contract:
+
+```bash
+cd packages/fetch/examples/pagination/react && npm install && npm run start   # http://localhost:3404
+cd packages/fetch/examples/pagination/vue   && npm install && npm run start   # http://localhost:3405
+```
+
+For framework dev mode (`npm run dev`), run the hub too — the Vite dev server proxies `/api` to it.
+
+## What to compare
+
+- **state** expresses the whole feature in HTML: a `url` getter recomputes when `page` changes,
+  `<wcs-fetch>` re-fetches and auto-aborts the prior request, and the list/pager are pure
+  `data-wcs` bindings — there is no imperative fetch code at all.
+- **signals** adapts the same `<wcs-fetch>` into signals with `bindNode()`: the element's `value`
+  / `loading` / `error` become read signals, and writing the `page`-derived `url` back with
+  `bindInput` makes the element refetch and auto-abort the previous request (switchMap-style
+  cancel/restart, owned by the element). No `resource()`, no hand-written `AbortController`.
+- **vanilla** consumes the same `<wcs-fetch>` with the smallest possible adapter: `@wc-bindable/core`'s
+  `bind()` streams the element's `value` / `loading` / `error` into a plain `state` object, and the
+  only thing left to hand-write is the DOM. No `AbortController`, no loading state machine — the
+  element owns those.
+- **React / Vue** subscribe to the same `<wcs-fetch>` through their framework adapter
+  (`useWcBindable`): derive the URL from `page`, hand it to the element, and the re-fetch, abort and
+  stale-response protection are the element's job — no `AbortController` wiring in `useEffect` / `watch`.

--- a/packages/fetch/examples/pagination/index.html
+++ b/packages/fetch/examples/pagination/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pagination, five ways — wcstack/fetch examples</title>
+  <link rel="stylesheet" href="/shared/style.css" />
+  <style>
+    .lead { color: var(--muted); font-size: 0.98rem; margin: 0.25rem 0 1.75rem; }
+    .cards { display: grid; gap: 0.9rem; grid-template-columns: 1fr; }
+    @media (min-width: 560px) { .cards { grid-template-columns: 1fr 1fr; } }
+    .card {
+      display: block;
+      text-decoration: none;
+      color: inherit;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 1.1rem 1.15rem;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+      transition: border-color 0.12s, transform 0.12s, box-shadow 0.12s;
+    }
+    .card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px rgba(57, 73, 171, 0.12);
+    }
+    .card h2 { font-size: 1.05rem; margin: 0.55rem 0 0.2rem; }
+    .card p { margin: 0; font-size: 0.85rem; color: var(--muted); line-height: 1.5; }
+    .card .port { display: inline-block; margin-top: 0.6rem; font-size: 0.74rem; color: var(--accent); font-variant-numeric: tabular-nums; }
+    .run {
+      margin-top: 2rem;
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 1.1rem 1.25rem;
+    }
+    .run h2 { font-size: 1rem; margin: 0 0 0.6rem; }
+    .run p { margin: 0.4rem 0; font-size: 0.86rem; color: var(--muted); }
+    .run code, .run pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .run pre {
+      background: #1a1a2e; color: #e8e8f0; padding: 0.8rem 1rem; border-radius: 8px;
+      overflow-x: auto; font-size: 0.8rem; line-height: 1.6; margin: 0.5rem 0;
+    }
+    .run code { background: #ececf3; padding: 1px 5px; border-radius: 4px; font-size: 0.86em; }
+  </style>
+</head>
+<body>
+  <div class="demo">
+    <header class="demo-header">
+      <span class="demo-badge">@wcstack/fetch</span>
+      <h1>Pagination, five ways</h1>
+    </header>
+    <p class="lead">
+      The same paginated member list — 200 records, 12 per page, server-side latency — built five
+      times against <strong>one shared server</strong>. The data, the markup and the styling are
+      identical; only the front-end approach changes. All five drive the
+      <strong>same headless <code>&lt;wcs-fetch&gt;</code> node</strong> through the wc-bindable
+      protocol — each via a different binding layer — so the fetch, the abort and the
+      stale-response protection live in the element, and the only thing that varies is how each
+      paradigm subscribes to it. Compare how each binds the page state, the re-fetch, and the
+      cancellation of a superseded request.
+    </p>
+
+    <div class="cards">
+      <a class="card" href="/state/">
+        <span class="demo-badge">@wcstack/state</span>
+        <h2>wcstack / state</h2>
+        <p>Declarative <code>&lt;wcs-fetch&gt;</code> + <code>data-wcs</code> bindings. No JavaScript glue — the URL getter drives the fetch.</p>
+      </a>
+
+      <a class="card" href="/signals/">
+        <span class="demo-badge">@wcstack/signals</span>
+        <h2>wcstack / signals</h2>
+        <p>Fine-grained signals: <code>bindNode()</code> adapts <code>&lt;wcs-fetch&gt;</code> into signals, and the element cancels the previous page on each change.</p>
+      </a>
+
+      <a class="card" href="/vanilla/">
+        <span class="demo-badge">Vanilla JS</span>
+        <h2>Vanilla</h2>
+        <p>Hand-built DOM, driven by a headless <code>&lt;wcs-fetch&gt;</code> node that <code>@wc-bindable/core</code>'s <code>bind()</code> streams into a plain state object. The framework-free baseline.</p>
+      </a>
+
+      <a class="card" href="http://localhost:3404/" target="_blank" rel="noopener"
+         title="Start the React demo first (see 'Running the demos' below) — it serves itself on :3404.">
+        <span class="demo-badge">React</span>
+        <h2>React</h2>
+        <p><code>useState</code> + a headless <code>&lt;wcs-fetch&gt;</code> node bound with <code>@wc-bindable/react</code>'s <code>useWcBindable</code> — the element owns the fetch + abort.</p>
+        <span class="port">runs on :3404 — start it first (see below)</span>
+      </a>
+
+      <a class="card" href="http://localhost:3405/" target="_blank" rel="noopener"
+         title="Start the Vue demo first (see 'Running the demos' below) — it serves itself on :3405.">
+        <span class="demo-badge">Vue</span>
+        <h2>Vue</h2>
+        <p>Composition API + a headless <code>&lt;wcs-fetch&gt;</code> node bound with <code>@wc-bindable/vue</code>'s <code>useWcBindable</code> — the element owns the fetch + abort.</p>
+        <span class="port">runs on :3405 — start it first (see below)</span>
+      </a>
+    </div>
+
+    <div class="run">
+      <h2>Running the demos</h2>
+      <p><strong>state / signals / vanilla</strong> are buildless — this page and all three are served by the shared hub:</p>
+      <pre>node packages/fetch/examples/pagination/shared/server.js
+# open http://localhost:3400</pre>
+      <p>(The signals demo imports the locally-built <code>@wcstack/signals</code> bundle — run <code>npm install &amp;&amp; npm run build</code> in <code>packages/signals</code> first.)</p>
+      <p><strong>React / Vue</strong> use Vite, so each builds and serves itself (reusing the same <code>/api/items</code>):</p>
+      <pre>cd packages/fetch/examples/pagination/react && npm install && npm run start   # :3404
+cd packages/fetch/examples/pagination/vue   && npm install && npm run start   # :3405</pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/packages/fetch/examples/pagination/react/README.ja.md
+++ b/packages/fetch/examples/pagination/react/README.ja.md
@@ -1,0 +1,55 @@
+# ページネーション — React
+
+共有ページネーションデモの React 19 実装です。200 件のメンバー一覧
+（1 ページ 12 件）を、他の 4 つのデモと同じ `/api/items` サーバーから取得します。
+データ・見た目・挙動はすべて同一で、違うのはフロントエンドのコードだけです。
+
+この実装では、ヘッドレスな `<wcs-fetch>`（`@wcstack/fetch` のデータノード）を
+`@wc-bindable/react` の `useWcBindable` で購読します。`page` から組み立てた `url` を
+要素に渡すだけで取得が走り、`useState` が保持するのは `page` だけ。`fetch` も
+`AbortController` も自前では書きません — 取得・abort・古いレスポンスの破棄はすべて
+要素側にあります。
+
+## 実行方法
+
+```bash
+cd packages/fetch/examples/pagination/react
+npm install
+npm run start          # ビルドして http://localhost:3404 で配信
+```
+
+ブラウザで http://localhost:3404 を開きます。`npm run start` だけで完結します。
+その `server.js` が同じポートで `/api/items` も配信するため、共有ハブを別途起動する
+必要は **ありません**（ハブが必要なのは下の `npm run dev` のときだけです）。
+
+ホットリロード付きの開発時:
+
+```bash
+# 1. 共有 API ハブを起動（/api/items を :3400 で配信）
+node packages/fetch/examples/pagination/shared/server.js
+
+# 2. 別のターミナルで
+cd packages/fetch/examples/pagination/react
+npm run dev           # Vite 開発サーバー。/api はハブへプロキシされる
+```
+
+## 注目ポイント
+
+- **取得は `<wcs-fetch>` に委譲。** `page` から `url` を組み立てて要素の `url` プロップ
+  に渡すと、要素が再取得し、進行中の前リクエストを自動 abort します。古いページの
+  遅いレスポンスが新しいページの行を上書きすることはありません（stale レスポンス
+  保護は要素側）。React 側に `fetch` も `AbortController` もありません。
+- **`useWcBindable` で状態を購読。** アダプタが要素の `value` / `loading` / `error` を
+  React state にミラーするので、派生値の算出と描画は通常の React のまま書けます。
+- **stale-while-revalidate。** 行が存在する状態で再読み込みすると、行はそのまま
+  表示し続けて `<ul>` に `stale` クラスを付けるだけです（初回ロードのスピナーは
+  最初のレスポンス前にだけ表示されます）。HTTP / ネットワークエラー時は `<wcs-fetch>`
+  が `value` を `null` に戻すため、`totalPages` は `1` にフォールバックし、ページャは
+  1 ページに最小化されます（5 デモ共通の復帰状態です）。
+- **`useMemo` のページウィンドウ。** `pageWindow(page, totalPages)` がページ一覧を
+  先頭 / 末尾 / 現在 ±1 に省略し、間を「…」で詰めます。ページ番号やページ数が
+  変わったときだけ再計算されます。
+
+5 つのデモ（React / Vue / `@wcstack/state` / `@wcstack/signals` / Vanilla）はすべて
+同じ共有 `/api/items` エンドポイントを叩き、しかも **5 つとも同一の `<wcs-fetch>` ノード**
+を、それぞれ異なる結線層（data-wcs / 各アダプタ / signals の `bindNode`）で消費しています。

--- a/packages/fetch/examples/pagination/react/README.md
+++ b/packages/fetch/examples/pagination/react/README.md
@@ -1,0 +1,59 @@
+# Pagination — React
+
+A React 19 implementation of the shared pagination demo. It paginates a
+200-row member list (12 per page) backed by the same `/api/items` server the
+other four demos use — so the data, look and behaviour are identical and only
+the front-end code differs.
+
+This one subscribes to a headless `<wcs-fetch>` node (the `@wcstack/fetch` data
+node) with `@wc-bindable/react`'s `useWcBindable`. The `url` prop is derived from
+`page` and handed to the element, which does the fetching; `useState` only holds
+`page`. There is no `fetch` and no `AbortController` here — the re-fetch, abort and
+stale-response protection all live in the element.
+
+## Run it
+
+```bash
+cd packages/fetch/examples/pagination/react
+npm install
+npm run start          # build + serve on http://localhost:3404
+```
+
+Then open http://localhost:3404. `npm run start` is self-contained: its `server.js`
+also serves `/api/items` on the same port, so you do **not** need to start the shared
+hub for it (the hub is only needed for `npm run dev` below).
+
+For live development with hot reload:
+
+```bash
+# 1. start the shared API hub (serves /api/items on :3400)
+node packages/fetch/examples/pagination/shared/server.js
+
+# 2. in another terminal
+cd packages/fetch/examples/pagination/react
+npm run dev           # Vite dev server; /api is proxied to the hub
+```
+
+## The interesting bits
+
+- **Fetching is delegated to `<wcs-fetch>`.** Deriving the `url` prop from `page`
+  and handing it to the element makes it refetch and auto-abort the previous
+  in-flight request, so a slow response for an old page can never overwrite the
+  newer page's rows (stale-response protection lives in the element). No `fetch`,
+  no `AbortController` on the React side.
+- **State via `useWcBindable`.** The adapter mirrors the element's `value` /
+  `loading` / `error` into React state, so the derived values and rendering are
+  plain React.
+- **Stale-while-revalidate.** Once rows exist, a reload keeps them on screen and
+  just adds the `stale` class to the `<ul>` (the first-load spinner only shows
+  before the very first response). On an HTTP/network error `<wcs-fetch>` resets
+  `value` to `null`, so `totalPages` falls back to `1` and the pager minimises to a
+  single page — the same recovery state in all five demos.
+- **`useMemo` page window.** `pageWindow(page, totalPages)` collapses the page
+  list to first / last / current ±1 with ellipsis gaps — recomputed only when
+  the page or page count changes.
+
+All five demos (React / Vue / `@wcstack/state` / `@wcstack/signals` / Vanilla) hit
+the same shared `/api/items` endpoint so the comparison stays apples-to-apples — and
+all five consume the very same `<wcs-fetch>` node, each through a different binding
+layer (data-wcs / framework adapter / signals' `bindNode`).

--- a/packages/fetch/examples/pagination/react/index.html
+++ b/packages/fetch/examples/pagination/react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>React — wcstack/fetch pagination</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/packages/fetch/examples/pagination/react/package-lock.json
+++ b/packages/fetch/examples/pagination/react/package-lock.json
@@ -1,0 +1,1847 @@
+{
+  "name": "wcstack-fetch-example-react-pagination",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wcstack-fetch-example-react-pagination",
+      "dependencies": {
+        "@wc-bindable/react": "^0.8.0",
+        "@wcstack/fetch": "^1.14.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.5.2",
+        "typescript": "^5.9.3",
+        "vite": "^6.3.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@wc-bindable/core": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wc-bindable/core/-/core-0.8.0.tgz",
+      "integrity": "sha512-nvZSL54sxaDc2N0LbwJSXQiuzXJ773h2smz82ZiIGQo30FDAtpYknULbbpjP91VmnXvrBn/4zoJSFn8yp1VtXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@wc-bindable/react": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wc-bindable/react/-/react-0.8.0.tgz",
+      "integrity": "sha512-LNVS0K0ynTgtmH1S8IfFC2GLGaS6BpXHqjX/V1Nc74tztWQa4dZfV+h8we4pbGQgWA89ILgd5CXySK7pardi+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@wc-bindable/core": "^0.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@wcstack/fetch": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@wcstack/fetch/-/fetch-1.14.0.tgz",
+      "integrity": "sha512-XoHLyCqiqcMwYKlqH2cw24ngtqQNJqbyABRWKWOpSFWePIllTyiyeRXGHtHrb0yirKCYIB27QF2UHhEQdphZew==",
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/packages/fetch/examples/pagination/react/package.json
+++ b/packages/fetch/examples/pagination/react/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "wcstack-fetch-example-react-pagination",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "npm run build && node server.js"
+  },
+  "dependencies": {
+    "@wc-bindable/react": "^0.8.0",
+    "@wcstack/fetch": "^1.14.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.5.2",
+    "typescript": "^5.9.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/packages/fetch/examples/pagination/react/server.js
+++ b/packages/fetch/examples/pagination/react/server.js
@@ -1,0 +1,11 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPaginationServer } from "../shared/server.js";
+
+const distDir = resolve(fileURLToPath(new URL(".", import.meta.url)), "dist");
+
+createPaginationServer({
+  port: Number(process.env.PORT || 3404),
+  staticRoot: distDir,
+  spaFallback: true,
+});

--- a/packages/fetch/examples/pagination/react/src/App.tsx
+++ b/packages/fetch/examples/pagination/react/src/App.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from "react";
+import { useWcBindable } from "@wc-bindable/react";
+
+const LIMIT = 12;
+
+type Role = "admin" | "editor" | "viewer";
+
+interface Member {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  joinedAt: string;
+}
+
+interface ItemsResponse {
+  items: Member[];
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * The wcBindable properties `<wcs-fetch>` mirrors into React state. `status` is
+ * not used by the UI here, but every demo mirrors it to show <wcs-fetch> exposes
+ * the HTTP status too.
+ */
+interface FetchValues {
+  value: ItemsResponse | null;
+  loading: boolean;
+  error: unknown;
+  status: number;
+}
+
+// Teach JSX about the headless <wcs-fetch> element (registered by
+// `@wcstack/fetch/auto` in main.tsx). Only its one driven input, `url`, is
+// declared as a JSX attribute — the output properties (value/loading/error/
+// status) are not JSX attributes; they are subscribed via useWcBindable below.
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "wcs-fetch": DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & { url?: string };
+    }
+  }
+}
+
+/** A page-button number, or a collapsed "gap" rendered as an ellipsis. */
+type PageToken = number | "gap";
+
+/**
+ * Always show: first page, last page, and current ±1; collapse gaps to an
+ * ellipsis. (Identical algorithm across all five framework demos.)
+ */
+function pageWindow(current: number, totalPages: number): PageToken[] {
+  const set = new Set([1, totalPages, current - 1, current, current + 1]);
+  const sorted = [...set].filter((p) => p >= 1 && p <= totalPages).sort((a, b) => a - b);
+  const out: PageToken[] = [];
+  let prev = 0;
+  for (const p of sorted) {
+    if (p - prev > 1) out.push("gap");
+    out.push(p);
+    prev = p;
+  }
+  return out; // e.g. [1, "gap", 4, 5, 6, "gap", 17]
+}
+
+export function App() {
+  const [page, setPage] = useState(1);
+
+  // Bind the headless <wcs-fetch> node: `bindRef` attaches the adapter to the
+  // element, `values` mirrors its wcBindable properties (value/loading/error/
+  // status) into React state. No fetch()/AbortController here — writing `url`
+  // (below) makes <wcs-fetch> refetch and abort the previous in-flight request,
+  // so stale-response protection lives in the element.
+  const [bindRef, values] = useWcBindable<HTMLElement, FetchValues>({
+    value: null,
+    loading: false,
+    error: null,
+    status: 0,
+  });
+
+  const url = `/api/items?page=${page}&limit=${LIMIT}`;
+
+  const data = values.value;
+  const loading = values.loading;
+  const error = values.error;
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.totalPages ?? 1;
+  const hasData = items.length > 0;
+
+  const tokens = useMemo(() => pageWindow(page, totalPages), [page, totalPages]);
+
+  const rangeText = hasData
+    ? `${(page - 1) * LIMIT + 1}–${(page - 1) * LIMIT + items.length} of ${total}` // EN DASH (U+2013)
+    : "Loading…";
+  const pageLabel = hasData ? `Page ${page} / ${totalPages}` : "";
+
+  const isFirst = page <= 1;
+  const isLast = page >= totalPages;
+
+  const go = (p: number) => {
+    if (p >= 1 && p <= totalPages && p !== page) setPage(p);
+  };
+
+  const firstLoading = loading && !hasData;
+
+  return (
+    <div className="demo">
+      <header className="demo-header">
+        <span className="demo-badge">React</span>
+        <h1>Pagination — React</h1>
+        <p>useState + &lt;wcs-fetch&gt; via @wc-bindable/react</p>
+      </header>
+
+      {/* Headless data node. Writing `url` triggers a fetch (and aborts the
+          previous one); `bindRef` streams its state into `values`. */}
+      <wcs-fetch ref={bindRef} url={url} />
+
+      <div className="panel">
+        <div className="toolbar">
+          <span className="status">{rangeText}</span>
+          <span className="status">{pageLabel}</span>
+        </div>
+
+        {firstLoading ? (
+          <div className="spinner" aria-hidden="true"></div>
+        ) : error ? (
+          <div className="error" role="alert">Failed to load. Try again.</div>
+        ) : (
+          // Only reached with rows present, so hasData is guaranteed and `loading`
+          // alone drives the stale dimming — matching the other four demos.
+          <ul className={loading ? "member-list stale" : "member-list"}>
+            {items.map((m) => (
+              <li key={m.id}>
+                <div className="member-item">
+                  <div className="member-main">
+                    <span className="member-name">{m.name}</span>
+                    <span className="member-email">{m.email}</span>
+                  </div>
+                  <div className="member-meta">
+                    <span className="member-date">{m.joinedAt}</span>
+                    <span className={`role-badge ${m.role}`}>{m.role}</span>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <nav className="pagination" aria-label="Pagination">
+          <button className="page-btn" disabled={isFirst} onClick={() => go(page - 1)}>
+            ‹ Prev
+          </button>
+          {tokens.map((tok, i) =>
+            tok === "gap" ? (
+              <span className="page-ellipsis" key={`gap-${i}`}>
+                …
+              </span>
+            ) : (
+              <button
+                className={tok === page ? "page-btn active" : "page-btn"}
+                disabled={tok === page}
+                aria-current={tok === page ? "page" : "false"}
+                onClick={() => go(tok)}
+                key={tok}
+              >
+                {tok}
+              </button>
+            ),
+          )}
+          <button className="page-btn" disabled={isLast} onClick={() => go(page + 1)}>
+            Next ›
+          </button>
+        </nav>
+      </div>
+
+      <p className="note">
+        React drives the headless <code>&lt;wcs-fetch&gt;</code> node declaratively:
+        the <code>url</code> prop is derived from <code>page</code>, and{" "}
+        <code>@wc-bindable/react</code>'s <code>useWcBindable</code> mirrors the
+        element's <code>value</code> / <code>loading</code> / <code>error</code> into
+        React state. The element refetches and aborts the previous request on its
+        own — no <code>AbortController</code> glue. It hits the same shared{" "}
+        <code>/api/items</code> server as the other four demos.
+      </p>
+    </div>
+  );
+}

--- a/packages/fetch/examples/pagination/react/src/main.tsx
+++ b/packages/fetch/examples/pagination/react/src/main.tsx
@@ -1,0 +1,6 @@
+import { createRoot } from "react-dom/client";
+import "@wcstack/fetch/auto"; // registers <wcs-fetch> (headless data node)
+import { App } from "./App";
+import "../../shared/style.css";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/packages/fetch/examples/pagination/react/tsconfig.json
+++ b/packages/fetch/examples/pagination/react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/fetch/examples/pagination/react/vite.config.js
+++ b/packages/fetch/examples/pagination/react/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: { outDir: "dist" },
+  // dev only: proxy the API to the shared hub (run it with
+  // `node packages/fetch/examples/pagination/shared/server.js`).
+  server: { proxy: { "/api": "http://localhost:3400" } },
+});

--- a/packages/fetch/examples/pagination/shared/data.js
+++ b/packages/fetch/examples/pagination/shared/data.js
@@ -1,0 +1,61 @@
+/**
+ * Shared mock dataset for the pagination examples.
+ *
+ * 200 deterministically-generated members — the SAME data is served to every
+ * framework demo (React / Vue / state / signals / Vanilla), so the only thing
+ * that differs between the examples is the front-end approach, never the data.
+ */
+
+const FIRST_NAMES = [
+  "Ada", "Linus", "Grace", "Alan", "Margaret", "Dennis", "Barbara", "Tim",
+  "Katherine", "Donald", "Edsger", "Hedy", "Claude", "Radia", "Vint", "Anita",
+  "John", "Marie", "Ken", "Sophie",
+];
+
+const LAST_NAMES = [
+  "Lovelace", "Torvalds", "Hopper", "Turing", "Hamilton", "Ritchie", "Liskov",
+  "Berners-Lee", "Johnson", "Knuth", "Dijkstra", "Lamarr", "Shannon", "Perlman",
+  "Cerf", "Borg", "Carmack", "Curie", "Thompson", "Wilson",
+];
+
+const ROLES = ["admin", "editor", "viewer"];
+
+function buildEmail(first, last, id) {
+  const local = `${first}.${last}`.toLowerCase().replace(/[^a-z.]/g, "");
+  return `${local}${id}@example.com`;
+}
+
+/** 200 members, generated once at module load (stable across requests). */
+export const MEMBERS = Array.from({ length: 200 }, (_, i) => {
+  const id = i + 1;
+  const first = FIRST_NAMES[i % FIRST_NAMES.length];
+  const last = LAST_NAMES[(i * 7) % LAST_NAMES.length];
+  const name = `${first} ${last}`;
+  const role = ROLES[i % ROLES.length];
+  // Deterministic join date spread across 2023-2024.
+  const year = 2023 + (i % 2);
+  const month = (i % 12) + 1;
+  const day = ((i * 3) % 28) + 1;
+  const joinedAt = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  return { id, name, email: buildEmail(first, last, id), role, joinedAt };
+});
+
+/**
+ * Page a list with 1-based page numbers. `page` is clamped to [1, totalPages]
+ * so an out-of-range request still returns a valid (edge) page rather than 404.
+ *
+ * @returns {{ items: object[], page: number, limit: number, total: number, totalPages: number }}
+ */
+export function paginate(members, page, limit) {
+  const total = members.length;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const clampedPage = Math.min(Math.max(1, page), totalPages);
+  const start = (clampedPage - 1) * limit;
+  return {
+    items: members.slice(start, start + limit),
+    page: clampedPage,
+    limit,
+    total,
+    totalPages,
+  };
+}

--- a/packages/fetch/examples/pagination/shared/package.json
+++ b/packages/fetch/examples/pagination/shared/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "wcstack-fetch-example-pagination-shared",
+  "private": true,
+  "type": "module"
+}

--- a/packages/fetch/examples/pagination/shared/server.js
+++ b/packages/fetch/examples/pagination/shared/server.js
@@ -1,0 +1,174 @@
+/**
+ * Shared demo server for the pagination examples.
+ *
+ * Every demo (React / Vue / state / signals / Vanilla) hits the SAME paginated
+ * endpoint produced here, so the comparison is apples-to-apples: identical data,
+ * identical latency, identical contract — only the front-end differs.
+ *
+ *   GET /api/items?page=<1-based>&limit=<n>
+ *     -> { items: [...], page, limit, total, totalPages }   (+ ~400ms latency)
+ *
+ * Two ways to run it:
+ *
+ *   1. As a hub (recommended for the buildless trio):
+ *        node packages/fetch/examples/pagination/shared/server.js
+ *      Serves the gallery + state/signals/vanilla demos + /api/items on :3400.
+ *
+ *   2. As a factory imported by a per-example server.js (React / Vue), which
+ *      serves that example's built `dist/` while reusing the same /api/items.
+ */
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, resolve, join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MEMBERS, paginate } from "./data.js";
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+};
+
+const API_DELAY_MS = 400;
+const DEFAULT_LIMIT = 12;
+
+function sendJson(res, data, status = 200) {
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "no-store",
+  });
+  res.end(JSON.stringify(data));
+}
+
+/**
+ * @param {object} options
+ * @param {number} options.port
+ * @param {string} options.staticRoot               Absolute dir to serve files from
+ * @param {string} [options.defaultFile="index.html"]  File served for "/"
+ * @param {boolean} [options.spaFallback=false]      Serve defaultFile for unknown paths
+ * @param {{prefix: string, dir: string}[]} [options.mounts]  Extra flat static mounts
+ *        (used to serve the locally-built @wcstack/signals dist under /signals/)
+ */
+export function createPaginationServer({
+  port,
+  staticRoot,
+  defaultFile = "index.html",
+  spaFallback = false,
+  mounts = [],
+}) {
+  const root = resolve(staticRoot);
+
+  async function serveFile(res, absPath, fallbackToIndex = false) {
+    try {
+      const content = await readFile(absPath);
+      const ext = extname(absPath);
+      res.writeHead(200, {
+        "Content-Type": MIME_TYPES[ext] || "application/octet-stream",
+        // Demo-local: serve every static file with "no-cache" so the browser
+        // revalidates and always picks up the latest edit. This matters most for
+        // the signals bundles (index.esm.js / dom.esm.js), whose names carry no
+        // content hash, so a rebuild keeps the same URL.
+        "Cache-Control": "no-cache",
+      });
+      res.end(content);
+    } catch {
+      if (fallbackToIndex) {
+        try {
+          const index = await readFile(resolve(root, defaultFile));
+          res.writeHead(200, {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-cache",
+          });
+          res.end(index);
+          return;
+        } catch { /* fall through to 404 */ }
+      }
+      res.writeHead(404);
+      res.end("Not Found");
+    }
+  }
+
+  const server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || "/", `http://${req.headers.host}`);
+      const path = url.pathname;
+
+      // --- Shared paginated API (the "common server" all five demos hit) ---
+      if (path === "/api/items") {
+        const rawPage = Number.parseInt(url.searchParams.get("page") || "1", 10);
+        const rawLimit = Number.parseInt(url.searchParams.get("limit") || String(DEFAULT_LIMIT), 10);
+        const page = Number.isFinite(rawPage) ? rawPage : 1;
+        const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 100) : DEFAULT_LIMIT;
+        await new Promise((r) => setTimeout(r, API_DELAY_MS)); // simulate network latency
+        return sendJson(res, paginate(MEMBERS, page, limit));
+      }
+
+      // --- Extra static mounts (e.g. the locally-built @wcstack/signals dist) ---
+      for (const m of mounts) {
+        if (path.startsWith(m.prefix)) {
+          const name = path.slice(m.prefix.length);
+          if (name && !name.includes("/") && !name.includes("..")) {
+            return serveFile(res, join(m.dir, name));
+          }
+          res.writeHead(404);
+          res.end("Not Found");
+          return;
+        }
+      }
+
+      // --- Static files ---
+      let rel;
+      if (path === "/") rel = defaultFile;
+      else if (path.endsWith("/")) rel = "." + path + "index.html";
+      else rel = "." + path;
+
+      const filePath = resolve(root, rel);
+      // Root-escape guard. url.pathname is already normalized (`..` segments are
+      // resolved away by the URL parser), so this is belt-and-braces — but match on
+      // the directory boundary `root + sep` (and root itself) rather than a bare
+      // prefix, so a sibling dir like `<root>-other` can never slip through.
+      if (filePath !== root && !filePath.startsWith(root + sep)) {
+        res.writeHead(403);
+        res.end("Forbidden");
+        return;
+      }
+      return serveFile(res, filePath, spaFallback);
+    } catch {
+      res.writeHead(400);
+      res.end("Bad Request");
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`Pagination demo running at http://localhost:${port}`);
+  });
+  return server;
+}
+
+// Direct run = the shared "hub": gallery + buildless demos + /api/items on one port.
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  const here = fileURLToPath(new URL(".", import.meta.url));
+  // The pagination set root: packages/fetch/examples/pagination
+  const setRoot = resolve(here, "..");
+  // The locally-built signals bundles live in the signals package's dist.
+  const signalsDist = resolve(here, "../../../../signals/dist");
+  createPaginationServer({
+    port: Number(process.env.PORT || 3400),
+    staticRoot: setRoot,
+    defaultFile: "index.html",
+    // Serve the signals bundles so the signals demo can import both entries
+    // (`@wcstack/signals` + `/dom`) and share one reactive core chunk.
+    // NB: prefix is /signals-dist/ (NOT /signals/) so it doesn't shadow the static
+    // route to the signals/ example directory.
+    mounts: [{ prefix: "/signals-dist/", dir: signalsDist }],
+  });
+}

--- a/packages/fetch/examples/pagination/shared/style.css
+++ b/packages/fetch/examples/pagination/shared/style.css
@@ -1,0 +1,255 @@
+/*
+ * Shared styles for the pagination examples.
+ *
+ * All five demos (React / Vue / state / signals / Vanilla) render the SAME DOM
+ * structure and pull in this one stylesheet, so they look identical and the only
+ * visible difference is the code behind them.
+ *
+ *   Buildless demos link it:   <link rel="stylesheet" href="/shared/style.css">
+ *   Vite demos import it:      import "../shared/style.css";
+ *
+ * Canonical markup each demo produces:
+ *
+ *   <div class="demo">
+ *     <header class="demo-header">
+ *       <span class="demo-badge">…</span><h1>…</h1><p>…</p>
+ *     </header>
+ *     <div class="panel">
+ *       <div class="toolbar">
+ *         <span class="status">1–12 of 200</span>
+ *         <span class="status">Page 1 / 17</span>
+ *       </div>
+ *       <ul class="member-list">              (add "stale" while reloading)
+ *         <li><div class="member-item">
+ *           <div class="member-main">
+ *             <span class="member-name">…</span><span class="member-email">…</span>
+ *           </div>
+ *           <div class="member-meta">
+ *             <span class="member-date">…</span>
+ *             <span class="role-badge admin|editor|viewer">…</span>
+ *           </div>
+ *         </div></li>
+ *       </ul>
+ *       <nav class="pagination">
+ *         <button class="page-btn">‹ Prev</button>
+ *         <button class="page-btn active">1</button>
+ *         <span class="page-ellipsis">…</span>
+ *         <button class="page-btn">17</button>
+ *         <button class="page-btn">Next ›</button>
+ *       </nav>
+ *     </div>
+ *     <p class="note">…</p>
+ *   </div>
+ */
+
+:root {
+  --accent: #3949ab;
+  --accent-strong: #303f9f;
+  --ink: #1a1a2e;
+  --muted: #6b6b7b;
+  --line: #e8e8ef;
+  --bg: #f6f6fb;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+  line-height: 1.5;
+}
+
+.demo {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+}
+
+.demo-header { margin-bottom: 1.25rem; }
+
+.demo-badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: #e8eaf6;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.demo-header h1 { font-size: 1.4rem; margin: 0.6rem 0 0.25rem; }
+.demo-header p { color: var(--muted); font-size: 0.92rem; margin: 0; }
+
+.panel {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  min-height: 1.4rem;
+}
+
+.status {
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Member list ----------------------------------------------------------- */
+
+.member-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-height: 6rem;
+  transition: opacity 0.15s;
+}
+
+/* Dim the current rows while the next page loads (stale-while-revalidate),
+   so the list never flashes empty between pages. */
+.member-list.stale { opacity: 0.45; }
+
+.member-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0.4rem;
+  border-bottom: 1px solid #f1f1f5;
+}
+
+.member-list li:last-child .member-item,
+.member-list > .member-item:last-child { border-bottom: none; }
+
+.member-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.member-name { font-weight: 600; }
+.member-email {
+  font-size: 0.8rem;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.member-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+
+.member-date {
+  font-size: 0.78rem;
+  color: #9a9aa8;
+  font-variant-numeric: tabular-nums;
+}
+
+.role-badge {
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #eef0fb;
+  color: var(--accent);
+  text-transform: capitalize;
+}
+.role-badge.admin { background: #fde8e8; color: #c0392b; }
+.role-badge.editor { background: #e8f1fd; color: #2563eb; }
+.role-badge.viewer { background: #eef7ee; color: #2e7d32; }
+
+/* --- Pagination controls --------------------------------------------------- */
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  margin-top: 1.25rem;
+}
+
+.page-btn {
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 0.6rem;
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--ink);
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.page-btn:hover:not(:disabled):not(.active) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.page-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: default;
+}
+.page-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.page-ellipsis {
+  min-width: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+  user-select: none;
+}
+
+/* --- States ---------------------------------------------------------------- */
+
+.spinner { display: flex; justify-content: center; padding: 2rem; }
+.spinner::after {
+  content: "";
+  width: 26px;
+  height: 26px;
+  border: 3px solid #e0e0e0;
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.error {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: #fce4ec;
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
+.note {
+  margin-top: 1.5rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
+.note code {
+  background: #ececf3;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.92em;
+}
+.note a { color: var(--accent); }

--- a/packages/fetch/examples/pagination/signals/README.ja.md
+++ b/packages/fetch/examples/pagination/signals/README.ja.md
@@ -1,0 +1,78 @@
+# ページネーション — `@wcstack/signals`
+
+同じページネーション付きメンバー一覧を 5 つの実装で並べて比較するデモのひとつです
+（React / Vue / `@wcstack/state` / `@wcstack/signals` / Vanilla JS）。5 つとも同一の
+DOM を描画し、同じスタイルシートを共有し、同じ `/api/items` エンドポイントを叩きます。
+違うのはフロントエンドのコードだけです。
+
+このバージョンは **`@wcstack/signals`**（ビルドレスなきめ細かいリアクティブコア）を
+使います。VDOM も DSL もありません。`signal()` / `computed()` を直接呼び、`h()` / `For()`
+で実 DOM を組み立てます。取得そのものは、他の 4 デモと同じヘッドレスな `<wcs-fetch>`
+（`@wcstack/fetch` のデータノード）に任せ、`bindNode()` でその要素を signals 化します。
+
+## 実行方法
+
+このデモはビルドレスで、共有の**ハブ**から配信されます。ハブはローカルビルドした
+`@wcstack/signals` のバンドル（`/signals-dist/` 配下）と `/api/items` エンドポイントも
+あわせて配信します。
+
+```bash
+# 1. signals パッケージを一度ビルドして dist/ を用意する（ハブが /signals-dist/ にマウントする）
+cd packages/signals && npm install && npm run build && cd -
+
+# 2. ハブを起動する
+node packages/fetch/examples/pagination/shared/server.js
+```
+
+ブラウザで <http://localhost:3400/signals/> を開きます。
+
+import map で signals の 2 つのエントリをローカルバンドルに、`@wcstack/fetch/auto`
+（`<wcs-fetch>` を登録）を CDN に割り当てています。
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "@wcstack/signals": "/signals-dist/index.esm.js",
+    "@wcstack/signals/dom": "/signals-dist/dom.esm.js",
+    "@wcstack/fetch/auto": "https://esm.run/@wcstack/fetch/auto"
+  }
+}
+</script>
+```
+
+このデモは実際には DOM レイヤー（`@wcstack/signals/dom`）からすべてを import します。
+DOM レイヤーはヘッドレスコア（`signal` / `computed` / `bindNode` / …）を DOM ヘルパー
+（`h` / `render` / `For`）と一緒に再 export しているので、この `/dom` 1 つの import で
+足ります。どちらのエントリのバンドルも同じ内部チャンク `core-<hash>.esm.js` を取り込む
+ため、ページが読み込むリアクティブインスタンスは常に 1 つです。`@wcstack/signals`
+エントリはコアを直接 import したいとき用に割り当てを残しているだけで、ここでは
+使いません。
+
+## 注目ポイント
+
+- **`bindNode()` で `<wcs-fetch>` を signals 化。** `bindNode(fetcher)` は要素の wc-bindable
+  記述子を読み取り、出力プロパティ（`value` / `loading` / `error`）を read signal として
+  公開します。`computed()` でその上に派生値を組めます。
+- **`bindInput()` で url を書き戻し → switchMap キャンセル。** `page` から組み立てた `url`
+  シグナルを `bound.bindInput("url", url)` で要素に書き戻すと、`page` が変わるたびに要素が
+  再取得し、進行中の前リクエストを自動 abort します（switchMap 相当のキャンセル／リスタートは
+  要素側）。`resource()` も手書きの `AbortController` も要りません。
+- **`h()` によるきめ細かい DOM。** `h(tag, props, ...children)` は実 DOM を一度だけ生成
+  します。関数で渡した子やプロパティ（`() => rangeText.get()`、`class: () => …`、
+  `disabled: () => …`）は対象を絞った effect に紐づき、依存シグナルが変わったときに
+  その 1 箇所だけが更新されます。
+- **`For()` によるキー付きリスト。** `<ul>` は `For(() => items.get(), …, { key: m => m.id })`
+  を使い、行を再生成せず id でキーイングして in-place に差分更新します。リストは
+  **一度だけ**生成してリロードをまたいでマウントし続けるため、ページ変更時も行の状態が
+  保持されます。
+- **Stale-while-revalidate。** 行が既にある状態でのリロードでは、行を画面に残したまま
+  `<ul>` に `stale` クラスを付けるだけです
+  （`class: () => loading ? "member-list stale" : "member-list"`）。リストは行が
+  存在してから初めてマウントされるので `loading` だけで十分です。
+  初回ロード用のスピナーは最初のレスポンスが来る前だけ表示されます。HTTP /
+  ネットワークエラー時は `<wcs-fetch>` が `value` を `null` に戻すため、`totalPages` は
+  `1` にフォールバックし、ページャは 1 ページに最小化されます（5 デモ共通の復帰状態です）。
+
+データはすべて共有の `/api/items?page=<n>&limit=12` サーバ（約 400ms のレイテンシ、
+200 件、17 ページ）から取得します。これは他の 4 つのデモと同じエンドポイントです。

--- a/packages/fetch/examples/pagination/signals/README.md
+++ b/packages/fetch/examples/pagination/signals/README.md
@@ -1,0 +1,77 @@
+# Pagination — `@wcstack/signals`
+
+One of five side-by-side implementations of the **same** paginated member list
+(React / Vue / `@wcstack/state` / `@wcstack/signals` / Vanilla JS). All five render
+identical DOM, share one stylesheet, and hit the same `/api/items` endpoint — only
+the front-end code differs.
+
+This version uses **`@wcstack/signals`**: a fine-grained, buildless reactive core. No
+VDOM, no DSL — you call `signal()` / `computed()` directly and build real DOM with
+`h()` / `For()`. The fetching itself is delegated to the same headless `<wcs-fetch>`
+node (the `@wcstack/fetch` data node) as the other four demos, adapted into signals
+with `bindNode()`.
+
+## How to run
+
+This demo is buildless and is served by the shared **hub**, which also serves the
+locally-built `@wcstack/signals` bundles (under `/signals-dist/`) and the `/api/items`
+endpoint:
+
+```bash
+# 1. Build the signals package once so dist/ exists (the hub mounts it at /signals-dist/)
+cd packages/signals && npm install && npm run build && cd -
+
+# 2. Start the hub
+node packages/fetch/examples/pagination/shared/server.js
+```
+
+Then open <http://localhost:3400/signals/>.
+
+The import map maps both signals entries to those local bundles, and `@wcstack/fetch/auto`
+(which registers `<wcs-fetch>`) to the CDN:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "@wcstack/signals": "/signals-dist/index.esm.js",
+    "@wcstack/signals/dom": "/signals-dist/dom.esm.js",
+    "@wcstack/fetch/auto": "https://esm.run/@wcstack/fetch/auto"
+  }
+}
+</script>
+```
+
+This demo actually imports everything from the DOM layer
+(`@wcstack/signals/dom`), which re-exports the whole headless core
+(`signal` / `computed` / `bindNode` / …) alongside the DOM helpers
+(`h` / `render` / `For`), so that single `/dom` import is enough. Each entry's
+bundle pulls in the same internal `core-<hash>.esm.js` chunk, so the page loads a
+single reactive instance regardless. The bare `@wcstack/signals` entry is kept
+mapped so you can also import the core directly — it just isn't needed here.
+
+## The interesting bits
+
+- **`bindNode()` adapts `<wcs-fetch>` into signals.** `bindNode(fetcher)` reads the
+  element's wc-bindable descriptor and exposes its output properties (`value` /
+  `loading` / `error`) as read signals you can build `computed()`s on top of.
+- **`bindInput()` writes the url back → switchMap cancel.** Writing the `page`-derived
+  `url` signal back with `bound.bindInput("url", url)` makes `<wcs-fetch>` refetch and
+  auto-abort the previous in-flight request whenever `page` changes (switchMap-style
+  cancel/restart, owned by the element). No `resource()`, no manual `AbortController`.
+- **Fine-grained DOM with `h()`.** `h(tag, props, ...children)` builds real DOM once.
+  A child or prop given as a function (`() => rangeText.get()`, `class: () => …`,
+  `disabled: () => …`) is wired to a targeted effect, so only that one binding updates
+  when its signals change.
+- **Keyed lists with `For()`.** The `<ul>` uses `For(() => items.get(), …, { key: m => m.id })`,
+  so rows are reconciled in place by id rather than rebuilt. The list is built **once**
+  and kept mounted across reloads, so its row state survives a page change.
+- **Stale-while-revalidate.** Once rows exist, a reload keeps them on screen and just
+  adds `stale` to the `<ul>` (`class: () => loading ? "member-list stale" : "member-list"`).
+  The list is only mounted once rows exist, so `loading` alone is enough. The
+  first-load spinner only shows before the very first response. On an HTTP/network error
+  `<wcs-fetch>` resets `value` to `null`, so `totalPages` falls back to `1` and the pager
+  minimises to a single page — the same recovery state in all five demos.
+
+All data comes from the shared `/api/items?page=<n>&limit=12` server (≈400 ms latency,
+200 items, 17 pages) — the same endpoint the other four demos use.

--- a/packages/fetch/examples/pagination/signals/index.html
+++ b/packages/fetch/examples/pagination/signals/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>signals — wcstack/fetch pagination</title>
+
+  <link rel="stylesheet" href="/shared/style.css" />
+
+  <!-- Map both signals entries to the locally-built bundles served by the hub at
+       /signals-dist/ (a distinct prefix so it doesn't shadow this /signals/ page).
+       This demo imports everything from the DOM layer (`@wcstack/signals/dom`),
+       which re-exports the whole headless core (signal/computed/bindNode/…) on top
+       of the DOM helpers (h/render/For), so the single `/dom` import is enough. Both
+       entries point at bundles that share ONE internal core chunk
+       (`core-<hash>.esm.js`), so even the DOM bundle alone loads a SINGLE reactive
+       instance. The `@wcstack/signals` entry is kept mapped so you can also import
+       the bare core directly — it just isn't needed here. `@wcstack/fetch/auto`
+       (which registers <wcs-fetch>) is pulled from the CDN. -->
+  <script type="importmap">
+  {
+    "imports": {
+      "@wcstack/signals": "/signals-dist/index.esm.js",
+      "@wcstack/signals/dom": "/signals-dist/dom.esm.js",
+      "@wcstack/fetch/auto": "https://esm.run/@wcstack/fetch/auto"
+    }
+  }
+  </script>
+</head>
+<body>
+
+<div class="demo">
+  <header class="demo-header">
+    <span class="demo-badge">@wcstack/signals</span>
+    <h1>Pagination — wcstack / signals</h1>
+    <p>Fine-grained signals binding a headless &lt;wcs-fetch&gt;</p>
+  </header>
+
+  <!-- Headless data node. bindNode() turns its wcBindable properties into signals,
+       and a reactive `url` input drives the fetch + abort. -->
+  <wcs-fetch id="fetcher"></wcs-fetch>
+
+  <!-- signals renders the reactive panel here -->
+  <div id="panel"></div>
+
+  <p class="note">
+    Fine-grained signals drive real DOM with <code>h()</code> and <code>For()</code>.
+    <code>bindNode()</code> adapts the headless <code>&lt;wcs-fetch&gt;</code> node into
+    signals (<code>value</code> / <code>loading</code> / <code>error</code>), and a
+    reactive <code>url</code> input — written back with <code>bindInput</code> — makes
+    the element refetch and abort the in-flight request on every page change, so no
+    stale response can land. Data comes from the shared <code>/api/items</code> server
+    (same endpoint as the other four demos).
+  </p>
+</div>
+
+<script type="module">
+  import "@wcstack/fetch/auto"; // registers <wcs-fetch> before we bind it
+  import { signal, computed, bindNode, h, render, For, createRoot } from "@wcstack/signals/dom";
+
+  const LIMIT = 12;
+
+  // Always show first, last and current ±1; collapse the gaps to an ellipsis.
+  function pageWindow(current, totalPages) {
+    const set = new Set([1, totalPages, current - 1, current, current + 1]);
+    const sorted = [...set].filter((p) => p >= 1 && p <= totalPages).sort((a, b) => a - b);
+    const out = [];
+    let prev = 0;
+    for (const p of sorted) {
+      if (p - prev > 1) out.push("gap");
+      out.push(p);
+      prev = p;
+    }
+    return out; // e.g. [1, "gap", 4, 5, 6, "gap", 17]
+  }
+
+  createRoot(() => {
+    const page = signal(1);
+
+    // Adapt the headless <wcs-fetch> node into signals. bindNode discovers the
+    // wc-bindable descriptor from the element and exposes its output properties
+    // (value/loading/error/status) as read signals seeded with the node's current
+    // values (value === null at rest).
+    const bound = bindNode(document.getElementById("fetcher"));
+    const valueSig = bound.signals.value;
+    const loadingSig = bound.signals.loading;
+    const errorSig = bound.signals.error;
+    // status is not used by the UI here, but every demo mirrors it to show
+    // <wcs-fetch> exposes the HTTP status too (bindNode signals it like the rest).
+    const statusSig = bound.signals.status;
+    void statusSig; // extension point: drop `statusSig.get()` into the toolbar to show it
+
+    // Reactively write the `url` input from `page`. Each change makes <wcs-fetch>
+    // refetch and abort the previous in-flight request (switchMap-style cancel/
+    // restart, owned by the element) — no resource(), no manual AbortController.
+    const url = computed(() => "/api/items?page=" + page.get() + "&limit=" + LIMIT);
+    bound.bindInput("url", url);
+
+    const body       = computed(() => valueSig.get());
+    const items      = computed(() => (body.get() ? body.get().items : []));
+    const total      = computed(() => (body.get() ? body.get().total : 0));
+    const totalPages = computed(() => (body.get() ? body.get().totalPages : 1));
+    const loading    = computed(() => !!loadingSig.get());
+    const hasData    = computed(() => items.get().length > 0);
+    const tokens     = computed(() => pageWindow(page.get(), totalPages.get()));
+
+    const rangeText = computed(() => {
+      if (!hasData.get()) return "Loading…";
+      const start = (page.get() - 1) * LIMIT + 1;
+      const end = start + items.get().length - 1;
+      return start + "–" + end + " of " + total.get(); // EN DASH (U+2013)
+    });
+    const pageLabel = computed(() =>
+      hasData.get() ? "Page " + page.get() + " / " + totalPages.get() : "",
+    );
+
+    const isFirst = computed(() => page.get() <= 1);
+    const isLast  = computed(() => page.get() >= totalPages.get());
+
+    // Show the first-load spinner only before the first response arrives.
+    const firstLoading = computed(() => loading.get() && !hasData.get());
+
+    const go = (p) => {
+      if (p >= 1 && p <= totalPages.get() && p !== page.get()) page.set(p);
+    };
+
+    // --- The member list (built ONCE so For row state survives reloads) ---------
+    // The <ul> gets class "member-list stale" while a reload is in flight
+    // (stale-while-revalidate: keep the rows, just dim them). The list is only
+    // mounted once rows exist (panelState below), so hasData is guaranteed here
+    // and `loading` alone is enough — matching the other four demos.
+    const list = h(
+      "ul",
+      {
+        class: () => (loading.get() ? "member-list stale" : "member-list"),
+      },
+      For(
+        () => items.get(),
+        (m) =>
+          h(
+            "li",
+            null,
+            h(
+              "div",
+              { class: "member-item" },
+              h(
+                "div",
+                { class: "member-main" },
+                h("span", { class: "member-name" }, m.name),
+                h("span", { class: "member-email" }, m.email),
+              ),
+              h(
+                "div",
+                { class: "member-meta" },
+                h("span", { class: "member-date" }, m.joinedAt),
+                h("span", { class: "role-badge " + m.role }, m.role),
+              ),
+            ),
+          ),
+        { key: (m) => m.id },
+      ),
+    );
+
+    // --- State switch: spinner (first load) | error | the list ------------------
+    // A reactive child: re-runs only when firstLoading / error change. During a
+    // stale reload (loading && hasData) neither changes, so the SAME `list` node is
+    // kept mounted and its For rows are not rebuilt.
+    const panelState = () => {
+      if (firstLoading.get()) {
+        return h("div", { class: "spinner", "aria-hidden": "true" });
+      }
+      if (errorSig.get()) {
+        return h("div", { class: "error", role: "alert" }, "Failed to load. Try again.");
+      }
+      return list;
+    };
+
+    // --- Pagination controls ----------------------------------------------------
+    const pager = h(
+      "nav",
+      { class: "pagination", "aria-label": "Pagination" },
+      h(
+        "button",
+        {
+          class: "page-btn",
+          disabled: () => isFirst.get(),
+          onClick: () => go(page.peek() - 1),
+        },
+        "‹ Prev",
+      ),
+      For(
+        () => tokens.get(),
+        (tok) => {
+          if (tok === "gap") {
+            return h("span", { class: "page-ellipsis" }, "…");
+          }
+          const n = tok;
+          return h(
+            "button",
+            {
+              class: () => (n === page.get() ? "page-btn active" : "page-btn"),
+              disabled: () => n === page.get(),
+              // aria-current marks the current page for screen readers.
+              "aria-current": () => (n === page.get() ? "page" : "false"),
+              onClick: () => go(n),
+            },
+            String(n),
+          );
+        },
+        // Unique, stable keys: numbers by value, gaps by position (a window has at
+        // most two gaps, and they never share an index).
+        { key: (tok, i) => (tok === "gap" ? "gap-" + i : "page-" + tok) },
+      ),
+      h(
+        "button",
+        {
+          class: "page-btn",
+          disabled: () => isLast.get(),
+          onClick: () => go(page.peek() + 1),
+        },
+        "Next ›",
+      ),
+    );
+
+    const panel = h(
+      "div",
+      { class: "panel" },
+      h(
+        "div",
+        { class: "toolbar" },
+        h("span", { class: "status" }, () => rangeText.get()),
+        h("span", { class: "status" }, () => pageLabel.get()),
+      ),
+      panelState,
+      pager,
+    );
+
+    render(panel, document.getElementById("panel"));
+  });
+</script>
+
+</body>
+</html>

--- a/packages/fetch/examples/pagination/state/README.ja.md
+++ b/packages/fetch/examples/pagination/state/README.ja.md
@@ -1,0 +1,52 @@
+# ページネーション — `@wcstack/state`
+
+宣言的な **`<wcs-fetch>` + `data-wcs` バインディングだけ** で作るメンバー一覧のページネーションです。
+`fetch()` の呼び出しも、loading/abort のつなぎコードも、JavaScript の配線も一切ありません。
+これは 5 つのデモ（React / Vue / `@wcstack/state` / `@wcstack/signals` / Vanilla）のひとつで、
+すべて同じ UI を同じ `/api/items` エンドポイントに対してレンダリングします。違いはアプローチだけです。
+
+## 使用しているもの
+
+- `@wcstack/state`（CDN: `esm.run`）
+- `@wcstack/fetch`（CDN: `esm.run`）
+
+## 実行方法
+
+このビルドレスデモは共有のページネーションハブが配信します（デモ個別のサーバーはありません）:
+
+```bash
+node packages/fetch/examples/pagination/shared/server.js
+```
+
+`http://localhost:3400/state/` を開いてください。
+
+ハブはギャラリー、他のビルドレスデモ、そしてライブの `/api/items` エンドポイントも配信します
+（`GET /api/items?page=<1始まり>&limit=12`、約 400ms の遅延、200 件 / 17 ページ）。
+
+## 見どころ
+
+- **JS のつなぎコードがゼロ。** すべての流れが HTML で完結します。算出 getter `itemsFetch.url` が
+  `page` から URL を組み立て、1 つの `<wcs-fetch data-wcs="...: itemsFetch">` がリクエストを実行し、
+  レスポンスの JSON が `itemsFetch.value` に入ります。テンプレートからは
+  `itemsFetch.value.items` / `.total` / `.totalPages` をそのまま読みます。
+- **古いレスポンスからの自動保護。** ページをクリックすると `page` が変わるだけです。URL getter が
+  再計算され、`<wcs-fetch>` が新しい `url` を検知し、**進行中の前のリクエストを自動的に中断** してから
+  新しいリクエストを開始します。`AbortController` も「これはまだ現在のページか？」という判定も不要です。
+- **宣言的な stale-while-revalidate。** `class.stale: itemsFetch.loading` が再読み込み中の現在の行を
+  スピナーに置き換えず薄く表示します。初回ロードのスピナーは、`loading` が true かつ行がまだ無いとき
+  （`firstLoading`）だけ表示されます。HTTP / ネットワークエラー時は `<wcs-fetch>` が `value` を `null`
+  に戻すため、`totalPages` は `1` にフォールバックし、ページャは 1 ページに最小化されます
+  （5 デモ共通の復帰状態です）。
+- **述語による相互排他。** `@wcstack/state` には `else` が無いため、3 つのブロック
+  （スピナー / エラー / リスト）はそれぞれ独立した `if` で、述語によって相互排他にしています。
+  `firstLoading`、`itemsFetch.error`、そして `showList`（= `!firstLoading && !error`）の 3 つです。
+  新しいレスポンスは `error` をクリアし、エラーは value をクリアするので、常にこの 3 つのうち
+  ちょうど 1 つだけが true になります。React / Vue / Vanilla / signals デモの `if/else-if/else`
+  チェーンと同じ挙動です。
+- **ページャをデータとして扱う。** `pageTokens` getter がページウィンドウ（先頭・末尾・現在 ±1、間は
+  省略記号に畳む）をオブジェクトの配列として返し、`for:` ループが各要素をボタンか省略記号に変換します。
+  `onclick` は引数を取れないため、クリックハンドラは `*` ループパス（`this["pageTokens.*"]`）で
+  クリックされたトークンを読み取ります。
+
+スプレッド `...: itemsFetch` は `<wcs-fetch>` のすべてのプロパティと入力
+（`url` / `value` / `loading` / `error` / `status` / …）を 1 行で `itemsFetch` スロットに配線します。

--- a/packages/fetch/examples/pagination/state/README.md
+++ b/packages/fetch/examples/pagination/state/README.md
@@ -1,0 +1,54 @@
+# Pagination — `@wcstack/state`
+
+Paginated member list built with **declarative `<wcs-fetch>` + `data-wcs` bindings only** —
+no `fetch()` calls, no loading/abort glue, no JavaScript wiring at all. This is one of five
+demos (React / Vue / `@wcstack/state` / `@wcstack/signals` / Vanilla) that render the exact
+same UI against the exact same `/api/items` endpoint, so the only difference is the approach.
+
+## What it uses
+
+- `@wcstack/state` via CDN (`esm.run`)
+- `@wcstack/fetch` via CDN (`esm.run`)
+
+## How to run
+
+This buildless demo is served by the shared pagination hub (no per-example server):
+
+```bash
+node packages/fetch/examples/pagination/shared/server.js
+```
+
+Then open `http://localhost:3400/state/`.
+
+The hub also serves the gallery, the other buildless demos, and the live `/api/items`
+endpoint (`GET /api/items?page=<1-based>&limit=12`, ~400 ms latency, 200 members / 17 pages).
+
+## The interesting bits
+
+- **Zero JS glue.** The whole flow is HTML: a computed `itemsFetch.url` getter rebuilds the
+  URL from `page`, one `<wcs-fetch data-wcs="...: itemsFetch">` runs the request, and the
+  response JSON lands in `itemsFetch.value` — read straight from the template as
+  `itemsFetch.value.items` / `.total` / `.totalPages`.
+- **Automatic stale-response protection.** Clicking a page only changes `page`; the URL
+  getter recomputes, `<wcs-fetch>` sees the new `url`, and it **aborts the previous in-flight
+  request** before starting the new one. No `AbortController`, no "is this still the current
+  page?" checks.
+- **Stale-while-revalidate, declaratively.** `class.stale: itemsFetch.loading` dims the
+  current rows during a reload instead of replacing them with a spinner; the first-load
+  spinner shows only when `loading` is true and there are no rows yet (`firstLoading`).
+  On an HTTP/network error `<wcs-fetch>` resets `value` to `null`, so `totalPages` falls
+  back to `1` and the pager minimises to a single page — the same recovery state in all
+  five demos.
+- **Mutual exclusion via predicates.** `@wcstack/state` has no `else`, so the three
+  blocks (spinner / error / list) are three independent `if`s made mutually exclusive by
+  their predicates: `firstLoading`, `itemsFetch.error`, and `showList` — the last defined
+  as `!firstLoading && !error`. Since a fresh response clears `error` and an error clears
+  the value, exactly one of the three is ever true, matching the `if/else-if/else` chain
+  in the React / Vue / Vanilla / signals demos.
+- **The pager as data.** A `pageTokens` getter returns the page window (first, last,
+  current ±1, with collapsed gaps) as objects, and a `for:` loop turns each into a button or
+  an ellipsis. The click handler reads the clicked token via the `*` loop path
+  (`this["pageTokens.*"]`) since `onclick` can't take arguments.
+
+The spread `...: itemsFetch` wires every `<wcs-fetch>` property and input
+(`url` / `value` / `loading` / `error` / `status` / …) to the `itemsFetch` slot in one line.

--- a/packages/fetch/examples/pagination/state/index.html
+++ b/packages/fetch/examples/pagination/state/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>wcstack / state — pagination</title>
+
+  <link rel="stylesheet" href="/shared/style.css">
+  <script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+  <script type="module" src="https://esm.run/@wcstack/fetch/auto"></script>
+</head>
+<body>
+
+<!-- ============================================================
+     App State
+     ============================================================
+     One <wcs-fetch> = one state slot, wired by the ...: spread.
+     A computed itemsFetch.url getter rebuilds the URL whenever
+     `page` changes; <wcs-fetch> sees a new url and auto-fetches
+     (aborting any in-flight request first → stale-response safe). -->
+<wcs-state>
+  <script type="module">
+    export default {
+      page: 1,
+      limit: 12,
+
+      // The whole JSON body lands in itemsFetch.value. Initialise only the
+      // fields the template paths read (itemsFetch.value.items / .total /
+      // .totalPages) so they resolve from the very first render. The real
+      // response carries page/limit too, but the UI never reads them, so we
+      // leave them out to keep this seed minimal. Uninitialised inputs
+      // (method/manual/…) are "no opinion" — the binder skips them and wcs-fetch
+      // keeps its defaults.
+      itemsFetch: {
+        value: { items: [], total: 0, totalPages: 1 },
+        // status is not used by the UI here, but every demo mirrors it to show
+        // <wcs-fetch> exposes the HTTP status too.
+        loading: false, error: null, status: 0,
+      },
+
+      // Recomputes whenever page/limit change → wcs-fetch sees a new url →
+      // it auto-fetches and aborts the previous in-flight request automatically.
+      get "itemsFetch.url"() {
+        return "/api/items?page=" + this.page + "&limit=" + this.limit;
+      },
+
+      // A property name that contains a dot (the slot key "itemsFetch.value",
+      // "itemsFetch.loading", …) is a single literal key, so it is read with bracket
+      // notation: this["itemsFetch.value"]. In `data-wcs` template paths the same dotted
+      // string is a PATH instead (itemsFetch.value.items walks value → items).
+      // Null-safe: on an HTTP/network error <wcs-fetch> resets value to null, so
+      // these read through optional chaining and fall back to empty/edge values.
+      get total()        { return this["itemsFetch.value"]?.total ?? 0; },
+      get totalPages()   { return this["itemsFetch.value"]?.totalPages ?? 1; },
+      get rowCount()     { return this["itemsFetch.value"]?.items?.length ?? 0; },
+      get hasData()      { return this.rowCount > 0; },
+      // First-load spinner only: loading AND no rows yet. On a reload we keep the
+      // old rows and just dim them (class.stale below), so the list never flashes.
+      get firstLoading() { return this["itemsFetch.loading"] && !this.hasData; },
+
+      // Show the list block only when we are neither first-loading nor errored, so
+      // the spinner / error / list blocks stay mutually exclusive — exactly like the
+      // if/else-if/else in the React / Vue / Vanilla / signals demos. During a reload
+      // showList stays true (loading but data still present), so the rows persist and
+      // just dim via class.stale.
+      get showList() { return !this.firstLoading && !this["itemsFetch.error"]; },
+
+      get rangeText() {
+        if (!this.hasData) return "Loading…";
+        const start = (this.page - 1) * this.limit + 1;
+        const end = start + this.rowCount - 1;
+        return start + "–" + end + " of " + this.total; // EN DASH (U+2013)
+      },
+      get pageLabel() {
+        return this.hasData ? "Page " + this.page + " / " + this.totalPages : "";
+      },
+
+      get isFirst() { return this.page <= 1; },
+      get isLast()  { return this.page >= this.totalPages; },
+
+      // Window of page tokens as OBJECTS so the for: template binds cleanly:
+      // numbers become buttons, gaps become an ellipsis. Identical algorithm to
+      // pageWindow() in the other four demos, just shaped for declarative binding.
+      get pageTokens() {
+        const set = new Set([1, this.totalPages, this.page - 1, this.page, this.page + 1]);
+        const sorted = [...set].filter((p) => p >= 1 && p <= this.totalPages).sort((a, b) => a - b);
+        const out = [];
+        let prev = 0;
+        for (const p of sorted) {
+          if (p - prev > 1) out.push({ gap: true, label: "…", page: 0, active: false, ariaCurrent: "false" });
+          const active = p === this.page;
+          // aria-current marks the current page for screen readers. We always set the
+          // attribute (page / false) so the bound element stays structurally identical
+          // across reloads — matching the other four demos.
+          out.push({ gap: false, label: String(p), page: p, active, ariaCurrent: active ? "page" : "false" });
+          prev = p;
+        }
+        return out;
+      },
+
+      // onclick binds a method by name and can't take an argument, so the handler
+      // reads the clicked loop item via the "*" path: "pageTokens.*" resolves to
+      // the token object of the button that was actually clicked.
+      goToPage() {
+        const tok = this["pageTokens.*"];
+        if (tok && !tok.gap && tok.page !== this.page) this.page = tok.page;
+      },
+      prevPage() { if (!this.isFirst) this.page -= 1; },
+      nextPage() { if (!this.isLast)  this.page += 1; },
+    };
+  </script>
+</wcs-state>
+
+<!-- Headless fetch node. ...: itemsFetch wires every wcBindable property + input
+     (url/value/loading/error/status/…) to the itemsFetch slot in one line. -->
+<wcs-fetch id="items-fetch" data-wcs="...: itemsFetch"></wcs-fetch>
+
+<!-- ============================================================
+     UI — the exact shared DOM structure
+     ============================================================ -->
+<div class="demo">
+  <header class="demo-header">
+    <span class="demo-badge">@wcstack/state</span>
+    <h1>Pagination — wcstack / state</h1>
+    <p>Declarative &lt;wcs-fetch&gt; + data-wcs — no JS glue</p>
+  </header>
+
+  <div class="panel">
+    <div class="toolbar">
+      <span class="status" data-wcs="textContent: rangeText"></span>
+      <span class="status" data-wcs="textContent: pageLabel"></span>
+    </div>
+
+    <!-- The other four demos make spinner / error / list structurally exclusive
+         with one if/else-if/else chain. state has no `else`, so instead these are
+         three independent `if`s made mutually exclusive by their PREDICATES:
+         firstLoading and itemsFetch.error never hold together (a fresh response
+         clears error and fills value; an error clears value, so firstLoading is
+         false), and showList is defined as their NOT (!firstLoading && !error).
+         Exactly one of the three is therefore true at any time. -->
+
+    <!-- (a) first-load spinner: loading && no rows yet -->
+    <template data-wcs="if: firstLoading">
+      <div class="spinner" aria-hidden="true"></div>
+    </template>
+
+    <!-- (b) error block -->
+    <template data-wcs="if: itemsFetch.error">
+      <div class="error" role="alert">Failed to load. Try again.</div>
+    </template>
+
+    <!-- (c) the list — shown only when not first-loading and not errored, so the
+         spinner / error / list blocks are mutually exclusive like the other four
+         demos. Kept on screen during reloads, dimmed via class.stale. The list is
+         only shown once rows exist, so `loading` alone drives the stale dimming
+         (hasData is guaranteed here) — matching the other four demos. -->
+    <template data-wcs="if: showList">
+      <ul class="member-list" data-wcs="class.stale: itemsFetch.loading">
+        <template data-wcs="for: itemsFetch.value.items">
+          <li>
+            <div class="member-item">
+              <div class="member-main">
+                <span class="member-name" data-wcs="textContent: .name"></span>
+                <span class="member-email" data-wcs="textContent: .email"></span>
+              </div>
+              <div class="member-meta">
+                <span class="member-date" data-wcs="textContent: .joinedAt"></span>
+                <span class="role-badge"
+                  data-wcs="textContent: .role;
+                            class.admin: .role|eq(admin);
+                            class.editor: .role|eq(editor);
+                            class.viewer: .role|eq(viewer)"></span>
+              </div>
+            </div>
+          </li>
+        </template>
+      </ul>
+    </template>
+
+    <nav class="pagination" aria-label="Pagination">
+      <button class="page-btn" data-wcs="onclick: prevPage; disabled: isFirst">‹ Prev</button>
+      <template data-wcs="for: pageTokens">
+        <template data-wcs="if: .gap">
+          <span class="page-ellipsis">…</span>
+        </template>
+        <template data-wcs="if: .gap|not">
+          <button class="page-btn"
+            data-wcs="onclick: goToPage; textContent: .label; class.active: .active; disabled: .active; attr.aria-current: .ariaCurrent"></button>
+        </template>
+      </template>
+      <button class="page-btn" data-wcs="onclick: nextPage; disabled: isLast">Next ›</button>
+    </nav>
+  </div>
+
+  <p class="note">
+    Pure HTML wiring: a computed <code>itemsFetch.url</code> drives one
+    <code>&lt;wcs-fetch&gt;</code>, and <code>data-wcs</code> paths render the
+    result — no <code>fetch()</code>, no loading/abort glue. Changing
+    <code>page</code> rebuilds the URL, so <code>&lt;wcs-fetch&gt;</code>
+    refetches and aborts the previous request automatically. It hits the shared
+    <code>/api/items</code> server, the same endpoint the React / Vue / signals /
+    Vanilla demos use.
+  </p>
+</div>
+
+</body>
+</html>

--- a/packages/fetch/examples/pagination/vanilla/README.ja.md
+++ b/packages/fetch/examples/pagination/vanilla/README.ja.md
@@ -1,0 +1,47 @@
+# Pagination — Vanilla JS
+
+共有ページネーションデモの、フレームワークを使わない実装です。素の ES モジュール、
+手書きの `state` オブジェクト、手組みの DOM 更新だけで、ビルドも要りません。ただし
+取得はヘッドレスな `<wcs-fetch>`（`@wcstack/fetch` のデータノード）に任せ、その状態を
+`@wc-bindable/core` の `bind()` で購読します。`fetch` も `AbortController` も自前では
+書きません。他の 4 デモ（React / Vue / `@wcstack/state` / `@wcstack/signals`）と **同じ**
+DOM を描画し、**同じ** `/api/items` サーバーを叩く比較の基準です。
+
+## 使用しているもの
+
+- `@wcstack/fetch`（CDN: `esm.run`）
+- `@wc-bindable/core`（CDN: `esm.run`）
+
+## 起動手順
+
+このデモは共有ハブから配信されます。デモ個別のサーバーはありません。
+
+```bash
+node packages/fetch/examples/pagination/shared/server.js
+```
+
+ブラウザで <http://localhost:3400/vanilla/> を開いてください。ハブは
+`/api/items`（全デモ共通のページネーションエンドポイント
+`GET /api/items?page=<1始まり>&limit=12`、約 400ms の遅延、200 件 / 17 ページ）
+も配信します。`@wc-bindable/core` はページ内の import map から
+CDN（esm.run）で解決します。
+
+## 注目ポイント
+
+- **取得は `<wcs-fetch>` に委譲** — `fetcher.url` を書き換えると要素が再取得し、
+  進行中の前リクエストを自動 abort します。新しいページに切り替わった後に解決した
+  古いレスポンスが新しいページを上書きすることはありません。`AbortController` の
+  手回しはここにはありません。
+- **最小アダプタ `bind()`** — `@wc-bindable/core` の `bind(fetcher, onUpdate)` が要素の
+  `value` / `loading` / `error` をプレーンな `state` に流し込み、変化のたびに `render()`
+  を呼びます。書くのは描画だけです。
+- **stale-while-revalidate** — 行が一度表示されたら、スピナーで置き換えることは
+  しません。次ページの読み込み中は `<ul>` に `stale` クラスを付けるだけなので、
+  リストが一瞬空になることがありません。これは **`<wcs-fetch>` の契約**に依存して
+  います。リロード進行中、要素は前回の `value` を保持し、次のレスポンスが来るまで
+  新しい `value` イベントを発火しないため、前ページの行がそのまま残ります。HTTP /
+  ネットワークエラー時は `<wcs-fetch>` が `value` を `null` に戻すため、`totalPages` は
+  `1` にフォールバックし、ページャは 1 ページに最小化されます（5 デモ共通の復帰状態です）。
+- **手組みの DOM** — ノードは `createElement` / `textContent` で生成し
+  （`innerHTML` への文字列埋め込みは使わない）、ページネーションの nav に
+  付けた 1 つのイベント委譲リスナーが `data-page` を読んでページを切り替えます。

--- a/packages/fetch/examples/pagination/vanilla/README.md
+++ b/packages/fetch/examples/pagination/vanilla/README.md
@@ -1,0 +1,49 @@
+# Pagination — Vanilla JS
+
+The framework-free implementation of the shared pagination demo: plain ES
+modules, a hand-rolled `state` object and DOM updates built by hand — no build
+step. The fetching, though, is delegated to a headless `<wcs-fetch>` node (the
+`@wcstack/fetch` data node), whose state is subscribed with `@wc-bindable/core`'s
+`bind()`. There is no `fetch` and no `AbortController` here. It renders the
+**same** DOM as the four other demos (React, Vue, `@wcstack/state`,
+`@wcstack/signals`) and hits the **same** `/api/items` server, so this is the
+baseline they are compared against.
+
+## What it uses
+
+- `@wcstack/fetch` via CDN (`esm.run`)
+- `@wc-bindable/core` via CDN (`esm.run`)
+
+## How to run
+
+This demo is served by the shared hub — there is no per-example server.
+
+```bash
+node packages/fetch/examples/pagination/shared/server.js
+```
+
+Then open <http://localhost:3400/vanilla/>. The hub also serves `/api/items`
+(the same paginated endpoint — `GET /api/items?page=<1-based>&limit=12`,
+~400 ms latency, 200 members / 17 pages — that every demo uses).
+`@wc-bindable/core` is resolved from the CDN (esm.run) via the page's import map.
+
+## The interesting bits
+
+- **Fetching is delegated to `<wcs-fetch>`** — writing `fetcher.url` makes the
+  element refetch and auto-abort the previous in-flight request, so a stale
+  response that resolves after a newer page change can never overwrite it. No
+  `AbortController` wiring here.
+- **`bind()`, the smallest adapter** — `@wc-bindable/core`'s `bind(fetcher, onUpdate)`
+  streams the element's `value` / `loading` / `error` into a plain `state` object
+  and calls `render()` on every change. The only thing left to write is the DOM.
+- **Stale-while-revalidate** — once rows exist they are never replaced by the
+  spinner; the `<ul>` just gets a `stale` class while the next page loads, so the
+  list never flashes empty. This relies on a **`<wcs-fetch>` contract**: while a
+  reload is in flight the element keeps the previous `value` and fires no new
+  `value` event until the next response lands, so the previous rows stay put. On an
+  HTTP/network error `<wcs-fetch>` resets `value` to `null`, so `totalPages` falls
+  back to `1` and the pager minimises to a single page — the same recovery state in
+  all five demos.
+- **Hand-built DOM** — nodes are created with `createElement` / `textContent`
+  (never `innerHTML` interpolation), and a single delegated click listener on the
+  pagination nav reads `data-page` to change pages.

--- a/packages/fetch/examples/pagination/vanilla/index.html
+++ b/packages/fetch/examples/pagination/vanilla/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vanilla — wcstack/fetch pagination</title>
+  <link rel="stylesheet" href="/shared/style.css" />
+
+  <!-- Resolve the wc-bindable core adapter from the CDN (buildless). -->
+  <script type="importmap">
+  {
+    "imports": {
+      "@wc-bindable/core": "https://esm.run/@wc-bindable/core"
+    }
+  }
+  </script>
+  <!-- Registers <wcs-fetch> (the headless data node). -->
+  <script type="module" src="https://esm.run/@wcstack/fetch/auto"></script>
+</head>
+<body>
+  <div class="demo">
+    <header class="demo-header">
+      <span class="demo-badge">Vanilla JS</span>
+      <h1>Pagination — Vanilla</h1>
+      <p>Hand-rolled state + DOM, &lt;wcs-fetch&gt; via @wc-bindable/core</p>
+    </header>
+
+    <!-- Headless data node: it owns the fetch, the abort and the
+         stale-response protection. We only mirror its state below. -->
+    <wcs-fetch id="fetcher"></wcs-fetch>
+
+    <!-- The script re-renders everything inside this panel. -->
+    <div class="panel" id="panel"></div>
+
+    <p class="note">
+      The framework-free baseline: a plain <code>&lt;wcs-fetch&gt;</code> node does
+      the fetching, and <code>@wc-bindable/core</code>'s <code>bind()</code> streams
+      its <code>value</code> / <code>loading</code> / <code>error</code> into a tiny
+      <code>state</code> object that drives hand-built DOM nodes. Setting
+      <code>fetcher.url</code> refetches and aborts the previous request — no
+      <code>AbortController</code> here. It hits the same shared
+      <code>/api/items</code> server as the React, Vue,
+      <code>@wcstack/state</code> and <code>@wcstack/signals</code> demos.
+    </p>
+  </div>
+
+  <script type="module">
+    import { bind } from "@wc-bindable/core";
+
+    const LIMIT = 12;
+    const fetcher = document.getElementById("fetcher");
+
+    // ----------------------------------------------------------------------
+    // View state — a single plain object, mirrored from <wcs-fetch> by bind()
+    // and re-rendered on every change. Nothing fancy.
+    // ----------------------------------------------------------------------
+    const state = {
+      page: 1,
+      data: null,     // last { items, total, totalPages, ... }; null while errored
+      loading: false,
+      error: null,
+      // Not used by the UI here, but every demo mirrors it to show <wcs-fetch>
+      // exposes the HTTP status too.
+      status: 0,
+    };
+
+    // The single source of truth for the page count: 1 until the first response
+    // lands (or after an error clears `data`). Derived in one place so goToPage()
+    // and render() agree — matching the single derived value in the other demos.
+    function totalPagesOf(data) {
+      return data ? data.totalPages : 1;
+    }
+
+    // The window of page tokens: first, last and current ±1, gaps collapsed to
+    // an ellipsis. e.g. [1, "gap", 4, 5, 6, "gap", 17].
+    function pageWindow(current, totalPages) {
+      const set = new Set([1, totalPages, current - 1, current, current + 1]);
+      const sorted = [...set].filter((p) => p >= 1 && p <= totalPages).sort((a, b) => a - b);
+      const out = [];
+      let prev = 0;
+      for (const p of sorted) {
+        if (p - prev > 1) out.push("gap");
+        out.push(p);
+        prev = p;
+      }
+      return out;
+    }
+
+    // Change the page by pointing <wcs-fetch> at a new URL. The element refetches
+    // and aborts any in-flight request automatically (stale-response safe), then
+    // pushes the new value/loading/error back to us through bind().
+    function goToPage(p) {
+      const totalPages = totalPagesOf(state.data);
+      if (p >= 1 && p <= totalPages && p !== state.page) {
+        state.page = p;
+        fetcher.url = "/api/items?page=" + p + "&limit=" + LIMIT;
+      }
+    }
+
+    // ----------------------------------------------------------------------
+    // Small DOM helpers — build nodes, never interpolate data into innerHTML.
+    // ----------------------------------------------------------------------
+    function el(tag, className, text) {
+      const node = document.createElement(tag);
+      if (className) node.className = className;
+      if (text != null) node.textContent = text;
+      return node;
+    }
+
+    function renderRow(item) {
+      const li = document.createElement("li");
+      const wrap = el("div", "member-item");
+
+      const main = el("div", "member-main");
+      main.append(
+        el("span", "member-name", item.name),
+        el("span", "member-email", item.email),
+      );
+
+      const meta = el("div", "member-meta");
+      meta.append(
+        el("span", "member-date", item.joinedAt),
+        el("span", "role-badge " + item.role, item.role),
+      );
+
+      wrap.append(main, meta);
+      li.append(wrap);
+      return li;
+    }
+
+    function renderPagination(page, totalPages) {
+      const nav = el("nav", "pagination");
+      nav.setAttribute("aria-label", "Pagination");
+
+      const prev = el("button", "page-btn", "‹ Prev");
+      prev.disabled = page <= 1;
+      prev.dataset.page = String(page - 1);
+      nav.append(prev);
+
+      for (const token of pageWindow(page, totalPages)) {
+        if (token === "gap") {
+          nav.append(el("span", "page-ellipsis", "…"));
+          continue;
+        }
+        const isActive = token === page;
+        const btn = el("button", "page-btn" + (isActive ? " active" : ""), String(token));
+        btn.disabled = isActive;
+        // aria-current marks the current page for screen readers.
+        btn.setAttribute("aria-current", isActive ? "page" : "false");
+        btn.dataset.page = String(token);
+        nav.append(btn);
+      }
+
+      const next = el("button", "page-btn", "Next ›");
+      next.disabled = page >= totalPages;
+      next.dataset.page = String(page + 1);
+      nav.append(next);
+
+      return nav;
+    }
+
+    // ----------------------------------------------------------------------
+    // Render the whole panel from the current state.
+    // ----------------------------------------------------------------------
+    function render() {
+      const { page, data, loading, error } = state;
+      const items = data ? data.items : [];
+      const total = data ? data.total : 0;
+      const totalPages = totalPagesOf(data);
+      const hasData = items.length > 0;
+
+      const panel = document.getElementById("panel");
+      panel.replaceChildren();
+
+      // Toolbar.
+      const toolbar = el("div", "toolbar");
+      const start = (page - 1) * LIMIT + 1;
+      const end = start + items.length - 1;
+      const rangeText = hasData
+        ? start + "–" + end + " of " + total // EN DASH (U+2013)
+        : "Loading…";
+      const pageLabel = hasData ? "Page " + page + " / " + totalPages : "";
+      toolbar.append(el("span", "status", rangeText), el("span", "status", pageLabel));
+      panel.append(toolbar);
+
+      // Exactly one of: first-load spinner / error / the list.
+      // NOTE: bind()'s initial sync (syncOn:"call") fires once with the element's
+      // resting values (loading=false, no data), so the very first render falls into
+      // the list branch and paints an empty <ul> for one frame. The url is set right
+      // after bind(), and on the next microtask <wcs-fetch> flips loading=true, so the
+      // spinner replaces that empty <ul> immediately. (All five demos share this
+      // initial loading=false → spinner transition.)
+      if (loading && !hasData) {
+        const spinner = el("div", "spinner");
+        spinner.setAttribute("aria-hidden", "true");
+        panel.append(spinner);
+      } else if (error) {
+        const errorBox = el("div", "error", "Failed to load. Try again.");
+        errorBox.setAttribute("role", "alert");
+        panel.append(errorBox);
+      } else {
+        // We only reach this branch with rows present, so hasData is guaranteed
+        // and `loading` alone decides the stale dimming — matching the other demos.
+        const ul = el("ul", "member-list" + (loading ? " stale" : ""));
+        for (const item of items) ul.append(renderRow(item));
+        panel.append(ul);
+      }
+
+      // Pagination is always shown so the user can recover from an error too.
+      panel.append(renderPagination(page, totalPages));
+    }
+
+    // ----------------------------------------------------------------------
+    // Mirror the <wcs-fetch> wcBindable properties into local state. `value` is
+    // null on an HTTP/network error, which clears the list (matching the other
+    // demos). The stale-while-revalidate behaviour rests on a <wcs-fetch>
+    // contract: while a reload is in flight the element holds the previous
+    // `value` and emits no new `value` event until the next response lands, so
+    // `state.data` (and the rendered rows) stay put and are only dimmed via the
+    // "stale" class.
+    // ----------------------------------------------------------------------
+    bind(fetcher, (name, value) => {
+      switch (name) {
+        case "value": state.data = value; break;
+        case "loading": state.loading = value; break;
+        case "error": state.error = value; break;
+        case "status": state.status = value; break; // mirrored but unused by the UI
+      }
+      render();
+    });
+
+    // ----------------------------------------------------------------------
+    // Event delegation on the panel: a single listener handles every page btn.
+    // ----------------------------------------------------------------------
+    document.getElementById("panel").addEventListener("click", (e) => {
+      const btn = e.target.closest("button.page-btn");
+      if (!btn || btn.disabled) return;
+      goToPage(Number(btn.dataset.page));
+    });
+
+    // Initial load: point <wcs-fetch> at page 1; the first-load spinner shows
+    // until it lands.
+    fetcher.url = "/api/items?page=1&limit=" + LIMIT;
+  </script>
+</body>
+</html>

--- a/packages/fetch/examples/pagination/vue/README.ja.md
+++ b/packages/fetch/examples/pagination/vue/README.ja.md
@@ -1,0 +1,53 @@
+# ページネーション — Vue
+
+共通ページネーションデモの **Vue 3** 実装です。Composition API（`ref` + `computed`）
+で組み立て、ヘッドレスな `<wcs-fetch>`（`@wcstack/fetch` のデータノード）を
+`@wc-bindable/vue` の `useWcBindable` で購読します。`page` から組み立てた `url` を
+`:url` で要素に渡すだけで取得が走り、`fetch` も `AbortController` も自前では書きません
+— 取得・abort・古いレスポンスの破棄はすべて要素側にあります。データも見た目も挙動も
+他の 4 デモと同一で、違うのはフロントエンドのコードだけです。
+
+> `<wcs-fetch>` をネイティブのカスタム要素として扱うため、`vite.config.js` で
+> `compilerOptions.isCustomElement`（`wcs-` 始まりのタグ）を設定しています。
+
+## 実行方法
+
+```bash
+cd packages/fetch/examples/pagination/vue
+npm install
+npm run start          # ビルドして dist を http://localhost:3405 で配信
+```
+
+ブラウザで <http://localhost:3405> を開きます。`npm run start` だけで完結します。
+その `server.js` が同じポートで `/api/items` も配信するため、共有ハブを別途起動する
+必要は **ありません**（ハブが必要なのは下の `npm run dev` のときだけです）。
+
+開発時にライブデータを使う場合は、`/api/items` を提供する共有ハブを起動してから
+Vite を起動します。dev サーバーは `/api` をハブにプロキシします:
+
+```bash
+# ターミナル 1 — 共有 API ハブ (:3400)
+node packages/fetch/examples/pagination/shared/server.js
+# ターミナル 2 — Vite dev サーバー
+cd packages/fetch/examples/pagination/vue && npm run dev
+```
+
+他の 4 つのデモと同じ共有エンドポイント
+`GET /api/items?page=<n>&limit=12` にアクセスします。
+
+## このアプローチの見どころ
+
+- **取得は `<wcs-fetch>` に委譲** — `page` から `url` を `computed` で組み立てて
+  `:url` で要素に渡すだけ。要素が再取得し、進行中の前リクエストを自動 abort する
+  ので、古いレスポンスが新しいページを上書きすることはありません。`load()` も
+  `AbortController` も要りません。
+- **`useWcBindable` で状態を購読** — アダプタが要素の `value` / `loading` / `error`
+  をリアクティブな `values` にミラーするので、派生値は通常どおり `computed` で
+  書けます。
+- **stale-while-revalidate** — 行が一度表示されたら、リロード中もスピナーで
+  ちらつかせず、`stale` クラスで薄く表示したまま維持します。スピナーは初回ロード時
+  のみ表示されます。HTTP / ネットワークエラー時は `<wcs-fetch>` が `value` を `null`
+  に戻すため、`totalPages` は `1` にフォールバックし、ページャは 1 ページに最小化
+  されます（5 デモ共通の復帰状態です）。
+- **派生値はすべて `computed`** — ページウィンドウのトークン・範囲テキスト・
+  ページラベルはすべて `computed` で、テンプレートは宣言的なまま保てます。

--- a/packages/fetch/examples/pagination/vue/README.md
+++ b/packages/fetch/examples/pagination/vue/README.md
@@ -1,0 +1,54 @@
+# Pagination — Vue
+
+A **Vue 3** implementation of the shared pagination demo. Built with the
+Composition API (`ref` + `computed`), it subscribes to a headless `<wcs-fetch>`
+node (the `@wcstack/fetch` data node) with `@wc-bindable/vue`'s `useWcBindable`.
+The `url` is derived from `page` and handed to the element via `:url`, so there is
+no `fetch` and no `AbortController` here — the re-fetch, abort and stale-response
+protection all live in the element. Same data, same look, same behaviour as the
+other four demos; only the front-end code differs.
+
+> `vite.config.js` sets `compilerOptions.isCustomElement` (tags starting with
+> `wcs-`) so the template compiler treats `<wcs-fetch>` as a native custom element.
+
+## How to run
+
+```bash
+cd packages/fetch/examples/pagination/vue
+npm install
+npm run start          # build + serve the dist on http://localhost:3405
+```
+
+Then open <http://localhost:3405>. `npm run start` is self-contained: its `server.js`
+also serves `/api/items` on the same port, so you do **not** need to start the shared
+hub for it (the hub is only needed for `npm run dev` below).
+
+For development with live data, run the shared hub (which provides `/api/items`)
+and start Vite — the dev server proxies `/api` to the hub:
+
+```bash
+# terminal 1 — shared API hub on :3400
+node packages/fetch/examples/pagination/shared/server.js
+# terminal 2 — Vite dev server
+cd packages/fetch/examples/pagination/vue && npm run dev
+```
+
+It hits the same shared `GET /api/items?page=<n>&limit=12` endpoint as the other
+four demos.
+
+## What's interesting here
+
+- **Fetching is delegated to `<wcs-fetch>`** — the `url` is a `computed` derived
+  from `page` and handed to the element via `:url`. The element refetches and
+  auto-aborts the previous in-flight request, so an older response can never
+  overwrite a newer page. No `load()`, no `AbortController`.
+- **State via `useWcBindable`** — the adapter mirrors the element's `value` /
+  `loading` / `error` into reactive `values`, so the derived values stay plain
+  `computed`s.
+- **Stale-while-revalidate** — once rows exist they are kept on screen (dimmed via
+  the `stale` class) during a reload instead of flashing the spinner; the spinner
+  only appears on the very first load. On an HTTP/network error `<wcs-fetch>` resets
+  `value` to `null`, so `totalPages` falls back to `1` and the pager minimises to a
+  single page — the same recovery state in all five demos.
+- **`computed` for everything derived** — the page-window tokens, range text and
+  page label are all `computed`, so the template stays declarative.

--- a/packages/fetch/examples/pagination/vue/index.html
+++ b/packages/fetch/examples/pagination/vue/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vue — wcstack/fetch pagination</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/packages/fetch/examples/pagination/vue/package-lock.json
+++ b/packages/fetch/examples/pagination/vue/package-lock.json
@@ -1,0 +1,1348 @@
+{
+  "name": "wcstack-fetch-example-vue-pagination",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wcstack-fetch-example-vue-pagination",
+      "dependencies": {
+        "@wc-bindable/vue": "^0.8.0",
+        "@wcstack/fetch": "^1.14.0",
+        "vue": "^3.5.13"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.2.4",
+        "vite": "^6.3.5"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
+      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
+      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
+      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.38",
+        "@vue/runtime-core": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
+      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38"
+      },
+      "peerDependencies": {
+        "vue": "3.5.38"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "license": "MIT"
+    },
+    "node_modules/@wc-bindable/core": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wc-bindable/core/-/core-0.8.0.tgz",
+      "integrity": "sha512-nvZSL54sxaDc2N0LbwJSXQiuzXJ773h2smz82ZiIGQo30FDAtpYknULbbpjP91VmnXvrBn/4zoJSFn8yp1VtXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@wc-bindable/vue": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wc-bindable/vue/-/vue-0.8.0.tgz",
+      "integrity": "sha512-SW2Vortz5EvI+UOx5Hy0CIL5hwAlREUcltDrU+JIJ+bQj1Vb/Pzqkvta3zsJLfq4TP1SHIm4NAAt1/ygNM61uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@wc-bindable/core": "^0.8.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3"
+      }
+    },
+    "node_modules/@wcstack/fetch": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@wcstack/fetch/-/fetch-1.14.0.tgz",
+      "integrity": "sha512-XoHLyCqiqcMwYKlqH2cw24ngtqQNJqbyABRWKWOpSFWePIllTyiyeRXGHtHrb0yirKCYIB27QF2UHhEQdphZew==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
+      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-sfc": "3.5.38",
+        "@vue/runtime-dom": "3.5.38",
+        "@vue/server-renderer": "3.5.38",
+        "@vue/shared": "3.5.38"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/fetch/examples/pagination/vue/package.json
+++ b/packages/fetch/examples/pagination/vue/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "wcstack-fetch-example-vue-pagination",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "npm run build && node server.js"
+  },
+  "dependencies": {
+    "@wc-bindable/vue": "^0.8.0",
+    "@wcstack/fetch": "^1.14.0",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.4",
+    "vite": "^6.3.5"
+  }
+}

--- a/packages/fetch/examples/pagination/vue/server.js
+++ b/packages/fetch/examples/pagination/vue/server.js
@@ -1,0 +1,11 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPaginationServer } from "../shared/server.js";
+
+const distDir = resolve(fileURLToPath(new URL(".", import.meta.url)), "dist");
+
+createPaginationServer({
+  port: Number(process.env.PORT || 3405),
+  staticRoot: distDir,
+  spaFallback: true,
+});

--- a/packages/fetch/examples/pagination/vue/src/App.vue
+++ b/packages/fetch/examples/pagination/vue/src/App.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { ref as vueRef, computed } from "vue";
+import { useWcBindable } from "@wc-bindable/vue";
+
+const LIMIT = 12;
+
+// --- page state ------------------------------------------------------------
+const page = vueRef(1);
+const url = computed(() => `/api/items?page=${page.value}&limit=${LIMIT}`);
+
+// Bind the headless <wcs-fetch> node: `fetcherRef` is attached to the element,
+// `values` mirrors its wcBindable properties (value/loading/error/status). No
+// fetch()/AbortController here — writing the `:url` (in the template) makes
+// <wcs-fetch> refetch and abort the previous in-flight request, so
+// stale-response protection lives in the element.
+// status is not used by the UI here, but every demo mirrors it to show
+// <wcs-fetch> exposes the HTTP status too.
+const { ref: fetcherRef, values } = useWcBindable({
+  value: null,
+  loading: false,
+  error: null,
+  status: 0,
+});
+
+// --- derived values --------------------------------------------------------
+const body = computed(() => values.value); // the <wcs-fetch> "value" property
+const items = computed(() => (body.value ? body.value.items : []));
+const total = computed(() => (body.value ? body.value.total : 0));
+const totalPages = computed(() => (body.value ? body.value.totalPages : 1));
+const loading = computed(() => values.loading);
+const hasData = computed(() => items.value.length > 0);
+const firstLoading = computed(() => loading.value && !hasData.value);
+
+const rangeText = computed(() => {
+  if (!hasData.value) return "Loading…";
+  const start = (page.value - 1) * LIMIT + 1;
+  const end = start + items.value.length - 1;
+  return `${start}–${end} of ${total.value}`; // EN DASH (U+2013)
+});
+
+const pageLabel = computed(() =>
+  hasData.value ? `Page ${page.value} / ${totalPages.value}` : ""
+);
+
+const isFirst = computed(() => page.value <= 1);
+const isLast = computed(() => page.value >= totalPages.value);
+
+// pageWindow: first, last, current ±1; collapse gaps to an ellipsis.
+function pageWindow(current, pages) {
+  const set = new Set([1, pages, current - 1, current, current + 1]);
+  const sorted = [...set].filter((p) => p >= 1 && p <= pages).sort((a, b) => a - b);
+  const out = [];
+  let prev = 0;
+  for (const p of sorted) {
+    if (p - prev > 1) out.push("gap");
+    out.push(p);
+    prev = p;
+  }
+  return out;
+}
+
+// Token objects carry a stable v-for key (numbers are unique; gaps key by index).
+const tokens = computed(() =>
+  pageWindow(page.value, totalPages.value).map((tok, i) =>
+    tok === "gap"
+      ? { kind: "gap", key: `gap-${i}` }
+      : { kind: "page", n: tok, key: `p-${tok}` }
+  )
+);
+
+// --- actions ---------------------------------------------------------------
+function go(p) {
+  if (p >= 1 && p <= totalPages.value && p !== page.value) page.value = p;
+}
+function prev() {
+  if (!isFirst.value) page.value -= 1;
+}
+function next() {
+  if (!isLast.value) page.value += 1;
+}
+</script>
+
+<template>
+  <div class="demo">
+    <header class="demo-header">
+      <span class="demo-badge">Vue</span>
+      <h1>Pagination — Vue</h1>
+      <p>Composition API + &lt;wcs-fetch&gt; via @wc-bindable/vue</p>
+    </header>
+
+    <!-- Headless data node. The reactive :url triggers a fetch (and aborts the
+         previous one); ref="fetcherRef" streams its state into `values`. -->
+    <wcs-fetch ref="fetcherRef" :url="url"></wcs-fetch>
+
+    <div class="panel">
+      <div class="toolbar">
+        <span class="status">{{ rangeText }}</span>
+        <span class="status">{{ pageLabel }}</span>
+      </div>
+
+      <!-- (a) first-load spinner: loading and no rows yet -->
+      <div v-if="firstLoading" class="spinner" aria-hidden="true"></div>
+
+      <!-- (b) error -->
+      <div v-else-if="values.error" class="error" role="alert">Failed to load. Try again.</div>
+
+      <!-- (c) the list: keep showing during reloads, dim it via "stale". Only
+           shown once rows exist, so hasData is guaranteed and `loading` alone
+           drives the stale dimming — matching the other four demos. -->
+      <ul v-else class="member-list" :class="{ stale: loading }">
+        <li v-for="m in items" :key="m.id">
+          <div class="member-item">
+            <div class="member-main">
+              <span class="member-name">{{ m.name }}</span>
+              <span class="member-email">{{ m.email }}</span>
+            </div>
+            <div class="member-meta">
+              <span class="member-date">{{ m.joinedAt }}</span>
+              <span class="role-badge" :class="m.role">{{ m.role }}</span>
+            </div>
+          </div>
+        </li>
+      </ul>
+
+      <nav class="pagination" aria-label="Pagination">
+        <button class="page-btn" :disabled="isFirst" @click="prev">‹ Prev</button>
+        <template v-for="tok in tokens" :key="tok.key">
+          <span v-if="tok.kind === 'gap'" class="page-ellipsis">…</span>
+          <button
+            v-else
+            class="page-btn"
+            :class="{ active: tok.n === page }"
+            :disabled="tok.n === page"
+            :aria-current="tok.n === page ? 'page' : 'false'"
+            @click="go(tok.n)"
+          >{{ tok.n }}</button>
+        </template>
+        <button class="page-btn" :disabled="isLast" @click="next">Next ›</button>
+      </nav>
+    </div>
+
+    <p class="note">
+      Vue drives the headless <code>&lt;wcs-fetch&gt;</code> node declaratively: the
+      <code>:url</code> is derived from <code>page</code>, and
+      <code>@wc-bindable/vue</code>'s <code>useWcBindable</code> mirrors the element's
+      <code>value</code> / <code>loading</code> / <code>error</code> into reactive
+      state. The element refetches and aborts the previous request on its own — no
+      <code>AbortController</code> glue. It hits the same shared
+      <code>/api/items</code> server as the other four demos.
+    </p>
+  </div>
+</template>

--- a/packages/fetch/examples/pagination/vue/src/main.js
+++ b/packages/fetch/examples/pagination/vue/src/main.js
@@ -1,0 +1,6 @@
+import { createApp } from "vue";
+import "@wcstack/fetch/auto"; // registers <wcs-fetch> (headless data node)
+import App from "./App.vue";
+import "../../shared/style.css";
+
+createApp(App).mount("#app");

--- a/packages/fetch/examples/pagination/vue/vite.config.js
+++ b/packages/fetch/examples/pagination/vue/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  // Treat <wcs-*> as native custom elements so the template compiler leaves
+  // them alone (and lets us bind `:url` on <wcs-fetch>) instead of trying to
+  // resolve them as Vue components.
+  plugins: [vue({ template: { compilerOptions: { isCustomElement: (tag) => tag.startsWith("wcs-") } } })],
+  build: { outDir: "dist" },
+  server: { proxy: { "/api": "http://localhost:3400" } },
+});


### PR DESCRIPTION
- Created package.json for Vue pagination example with necessary dependencies and scripts.
- Implemented server.js to serve the built application and handle SPA fallback.
- Developed App.vue to manage pagination logic and UI, utilizing @wc-bindable/vue for data binding.
- Added main.js to initialize the Vue application and register the <wcs-fetch> component.
- Configured vite.config.js to handle custom elements and set up API proxy for local development.