### PR TITLE
docs(examples): switch state-sse-dashboard to the released CDN state build

### DIFF
--- a/examples/README.ja.md
+++ b/examples/README.ja.md
@@ -12,14 +12,13 @@
 すべてのデモはビルドレスで、パッケージを CDN から直接ロードします
 （`https://esm.run/@wcstack/<pkg>/auto` の 1 行。signals デモは単一の
 `@wcstack/signals/dom` エントリを import）。例外は `websocket-chat` の
-React / Vue variant（Vite 使用）と、`$streams` がリリースされるまで
-ローカルの `packages/state` ビルドを import する `state-sse-dashboard` です。
+React / Vue variant（Vite 使用）のみです。
 
 **script の順序**: I/O ノード系パッケージを `@wcstack/state` より*先*に並べて
 ください。module script は文書順で実行されるため、state がバインディングを
-確立する時点で全カスタム要素の define が保証されます — 逆順だと、ノード側の
-ロードが state より遅い構成（例: ローカルの state ビルドと CDN の競走）で、
-未 define 要素への初期 state→element 適用がスキップされることがあります。
+確立する時点で全カスタム要素の define が保証されます（state は未 define 要素
+への初期 state→element 書き込みを `customElements.whenDefined` 後に再適用する
+ため、この順序は必須要件ではなくベストプラクティスです）。
 
 ## デモ一覧
 
@@ -36,7 +35,7 @@ React / Vue variant（Vite 使用）と、`$streams` がリリースされるま
 | [`state-permission-banner/`](state-permission-banner/) | geolocation + permission + state | 任意の静的サーバー | — |
 | [`state-pomodoro/`](state-pomodoro/) | timer + wakelock + notification + state | 任意の静的サーバー（secure context 必須） | — |
 | [`state-search/`](state-search/) | fetch + debounce + state | `node examples/state-search/server.js` | :3000 |
-| [`state-sse-dashboard/`](state-sse-dashboard/) | sse + state（`$streams`）+ network — 1 フィード・2 流儀 | `node examples/state-sse-dashboard/server.js`（先に `packages/state` をビルド — `$streams` 未リリースのため） | :3000 |
+| [`state-sse-dashboard/`](state-sse-dashboard/) | sse + state（`$streams`）+ network — 1 フィード・2 流儀 | `node examples/state-sse-dashboard/server.js` | :3000 |
 | [`state-tilt-maze/`](state-tilt-maze/) | tilt + accelerometer + raf + wakelock + state（センサーゲーム） | 任意の静的サーバー（secure context 必須） | — |
 | [`signals-live-search/`](signals-live-search/) | signals + fetch | `node examples/signals-live-search/server.js` | :3000 |
 | [`signals-tilt-maze/`](signals-tilt-maze/) | signals × `state-tilt-maze` と同じ 4 センサーノード（コア差し替え比較） | 任意の静的サーバー（secure context 必須） | — |

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,14 +12,13 @@ single-package demos live in that package's own `examples/` directory instead:
 Every demo is buildless and loads packages straight from the CDN
 (`https://esm.run/@wcstack/<pkg>/auto` one-liners; signals demos import the
 single `@wcstack/signals/dom` entry) — except the React/Vue variants of
-`websocket-chat`, which use Vite, and `state-sse-dashboard`, which imports the
-local `packages/state` build until `$streams` ships in a release.
+`websocket-chat`, which use Vite.
 
 **Script order**: list the I/O-node packages *before* `@wcstack/state`. Module
 scripts execute in document order, so this guarantees every custom element is
-defined before state attaches its bindings — otherwise, when the node packages
-load slower than state (e.g. a local state build racing the CDN), the initial
-state→element apply can be skipped for not-yet-defined elements.
+defined before state attaches its bindings. (state also re-applies the initial
+state→element write via `customElements.whenDefined` for late-defined
+elements, so this ordering is a best practice rather than a hard requirement.)
 
 ## Demo list
 
@@ -36,7 +35,7 @@ state→element apply can be skipped for not-yet-defined elements.
 | [`state-permission-banner/`](state-permission-banner/) | geolocation + permission + state | any static server | — |
 | [`state-pomodoro/`](state-pomodoro/) | timer + wakelock + notification + state | any static server (secure context) | — |
 | [`state-search/`](state-search/) | fetch + debounce + state | `node examples/state-search/server.js` | :3000 |
-| [`state-sse-dashboard/`](state-sse-dashboard/) | sse + state (`$streams`) + network — one feed, two idioms | `node examples/state-sse-dashboard/server.js` (build `packages/state` first — unreleased `$streams`) | :3000 |
+| [`state-sse-dashboard/`](state-sse-dashboard/) | sse + state (`$streams`) + network — one feed, two idioms | `node examples/state-sse-dashboard/server.js` | :3000 |
 | [`state-tilt-maze/`](state-tilt-maze/) | tilt + accelerometer + raf + wakelock + state (sensor game) | any static server (secure context) | — |
 | [`signals-live-search/`](signals-live-search/) | signals + fetch | `node examples/signals-live-search/server.js` | :3000 |
 | [`signals-tilt-maze/`](signals-tilt-maze/) | signals × the same 4 sensor nodes as `state-tilt-maze` (core swap comparison) | any static server (secure context) | — |

--- a/examples/state-sse-dashboard/README.ja.md
+++ b/examples/state-sse-dashboard/README.ja.md
@@ -10,13 +10,10 @@
 ## 起動方法
 
 ```bash
-# $streams は未リリースのため、まずローカルの state をビルド:
-cd packages/state && npm run build && cd ../..
-
 node examples/state-sse-dashboard/server.js
 ```
 
-http://localhost:3000 を開いてください。サーバーは `packages/state/dist` を `/state-dist/` にマウントします（ページは CDN でなくローカルビルドを import）。`sse` / `network` は通常どおり CDN からロードします。`$streams` がリリースに載ったら、ローカルマウントは標準の CDN 1 行に置き換えられます。
+http://localhost:3000 を開いてください。3 パッケージ（`state` / `sse` / `network`）はすべて CDN からロードします — `$streams` は v1.19.0 でリリース済みのため、ローカルビルドは不要です。
 
 ## 見せ場: ホスト切り替え
 

--- a/examples/state-sse-dashboard/README.md
+++ b/examples/state-sse-dashboard/README.md
@@ -10,13 +10,10 @@ One Server-Sent Events feed, consumed twice on the same page:
 ## Getting Started
 
 ```bash
-# $streams is unreleased — build the local state bundle once first:
-cd packages/state && npm run build && cd ../..
-
 node examples/state-sse-dashboard/server.js
 ```
 
-Open http://localhost:3000. The server mounts `packages/state/dist` under `/state-dist/` (the page imports the local build instead of the CDN); `sse` / `network` load from the CDN as usual. Once `$streams` ships in a release, the local mount can be replaced by the standard CDN one-liner.
+Open http://localhost:3000. All three packages (`state` / `sse` / `network`) load from the CDN — `$streams` ships since v1.19.0, so no local build is needed.
 
 ## The punchline: switch hosts
 

--- a/examples/state-sse-dashboard/index.html
+++ b/examples/state-sse-dashboard/index.html
@@ -43,19 +43,16 @@
     code { font-family: ui-monospace, monospace; font-size: 0.95em; }
   </style>
 
-  <!-- $streams is not released yet: the local packages/state/dist build is
-       mounted under /state-dist/ by server.js (run `npm run build` in
-       packages/state first). sse / network load from the CDN as usual.
+  <!-- All three packages load from the CDN ($streams ships since v1.19.0).
 
-       ORDER MATTERS: module scripts execute in document order, so listing the
-       I/O nodes BEFORE state guarantees their elements are defined by the time
-       state initializes its bindings. The initial state→element apply is
-       silently skipped for not-yet-defined custom elements (and not replayed),
-       so with the fast local state build racing the CDN, `url: sseUrl` would
-       otherwise never be written and the left panel would stay silent. -->
+       Module scripts execute in document order, so listing the I/O nodes
+       BEFORE state keeps their elements defined by the time state initializes
+       its bindings. (state also re-applies the initial state→element write
+       via customElements.whenDefined for late-defined elements, so this
+       ordering is a best practice rather than a hard requirement.) -->
   <script type="module" src="https://esm.run/@wcstack/sse/auto"></script>
   <script type="module" src="https://esm.run/@wcstack/network/auto"></script>
-  <script type="module" src="/state-dist/auto.js"></script>
+  <script type="module" src="https://esm.run/@wcstack/state/auto"></script>
 </head>
 <body>
 

--- a/examples/state-sse-dashboard/server.js
+++ b/examples/state-sse-dashboard/server.js
@@ -1,30 +1,23 @@
 /**
  * Demo server for the SSE dashboard example (sse + state($streams) + network).
  *
- * Two things beyond static file serving, both through the shared server's raw
+ * One thing beyond static file serving, through the shared server's raw
  * (req, res) api hook:
  *
- *   1. GET /api/metrics?host=a|b
- *      A Server-Sent Events stream: a named "metric" event every ~600ms with a
- *      host-specific CPU/RPS profile (so switching hosts is visible on the
- *      charts), plus an occasional named "deploy" event. Streaming is exactly
- *      what the api hook permits: write the event-stream headers, keep
- *      writing, return true — and never call res.end().
+ *   GET /api/metrics?host=a|b
+ *   A Server-Sent Events stream: a named "metric" event every ~600ms with a
+ *   host-specific CPU/RPS profile (so switching hosts is visible on the
+ *   charts), plus an occasional named "deploy" event. Streaming is exactly
+ *   what the api hook permits: write the event-stream headers, keep
+ *   writing, return true — and never call res.end().
  *
- *   2. /state-dist/*
- *      The LOCAL packages/state/dist build. $streams is not released yet, so
- *      the page imports the local state bundle instead of the CDN (run
- *      `npm run build` in packages/state first). sse / network still load
- *      from the CDN as usual.
+ * All wcstack packages (state / sse / network) load from the CDN — $streams
+ * ships since v1.19.0, so no local build mount is needed.
  */
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { extname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createDemoServer } from "../shared/server.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
-const stateDistRoot = resolve(__dirname, "..", "..", "packages", "state", "dist");
 
 const METRIC_INTERVAL_MS = 600;
 const DEPLOY_EVERY = 12; // one "deploy" event per N "metric" events
@@ -33,13 +26,6 @@ const DEPLOY_EVERY = 12; // one "deploy" event per N "metric" events
 const HOSTS = {
   a: { cpuBase: 32, cpuSwing: 16, rpsBase: 120, major: 3 },
   b: { cpuBase: 68, cpuSwing: 14, rpsBase: 480, major: 7 },
-};
-
-const DIST_MIME = {
-  ".js": "application/javascript; charset=utf-8",
-  ".map": "application/json; charset=utf-8",
-  ".json": "application/json; charset=utf-8",
-  ".ts": "text/plain; charset=utf-8",
 };
 
 function handleMetrics(req, res, url) {
@@ -73,34 +59,6 @@ function handleMetrics(req, res, url) {
   req.on("close", () => clearInterval(timer));
 }
 
-async function serveStateDist(res, relPath) {
-  const filePath = resolve(stateDistRoot, relPath);
-  // Path traversal guard: the resolved path must stay inside the dist root.
-  if (filePath !== stateDistRoot && !filePath.startsWith(stateDistRoot + sep)) {
-    res.writeHead(403);
-    res.end("Forbidden");
-    return;
-  }
-  try {
-    const content = await readFile(filePath);
-    res.writeHead(200, {
-      "Content-Type": DIST_MIME[extname(filePath)] || "application/octet-stream",
-      "Cache-Control": "no-cache",
-    });
-    res.end(content);
-  } catch {
-    res.writeHead(404);
-    res.end("Not Found");
-  }
-}
-
-if (!existsSync(resolve(stateDistRoot, "auto.js"))) {
-  console.warn(
-    "[sse-dashboard] packages/state/dist not found — run `npm run build` in packages/state first\n" +
-    "                ($streams is unreleased; this demo imports the local state build, not the CDN).",
-  );
-}
-
 createDemoServer({
   port: Number(process.env.PORT || 3000),
   root: __dirname,
@@ -109,14 +67,9 @@ createDemoServer({
       handleMetrics(req, res, url);
       return true; // handled — the stream stays open, so res is ours to keep
     }
-    if (url.pathname.startsWith("/state-dist/")) {
-      await serveStateDist(res, "." + url.pathname.slice("/state-dist".length));
-      return true;
-    }
     return false;
   },
   notes: [
     "SSE stream: /api/metrics?host=a|b (metric every 600ms + an occasional deploy)",
-    "/state-dist/ serves the local packages/state/dist build (unreleased $streams)",
   ],
 });


### PR DESCRIPTION
$streams shipped in @wcstack/state v1.19.0, so the demo no longer needs the local packages/state/dist mount: index.html now imports esm.run/@wcstack/state/auto like every other demo, and server.js drops the /state-dist/ file route, its MIME table, and the missing-build warning. READMEs (example + examples index, en/ja) lose the build-first step.

Also update the script-order rationale in the same comments: since the deferred-apply fix shipped (initial state->element writes are re-applied via customElements.whenDefined for late-defined elements), listing I/O nodes before state is a best practice rather than a hard requirement.

Smoke-tested: server starts, / serves the CDN-importing page with no state-dist references, /api/metrics streams text/event-stream.