### PR TITLE
feat: Enhance state analysis and validation for command and event tokens

### DIFF
--- a/packages/state/__tests__/manifest.test.ts
+++ b/packages/state/__tests__/manifest.test.ts
@@ -67,5 +67,8 @@ describe("wcs-manifest（単一正本・A2-1）", () => {
     expect(m.reservedLifecycle).toContain("$updatedCallback");
     expect(m.reservedStateApi).toContain("$commandTokens");
     expect(m.reservedStateApi).toContain("$on");
+    expect(m.reservedStateApi).toContain("$streams");
+    expect(m.reservedStateApi).toContain("$streamStatus");
+    expect(m.reservedStateApi).toContain("$streamError");
   });
 });

--- a/packages/state/src/defineState.ts
+++ b/packages/state/src/defineState.ts
@@ -40,10 +40,13 @@ type IsPlainObject<T> =
 /**
  * T のキーのうち、関数でないもの（データプロパティ・computed getter）を抽出する。
  * メソッド（イベントハンドラ等）はドットパスの対象外。
+ * `$` プレフィックスキー（$streams / $commandTokens / $on 等の予約宣言）もドットパスにならない。
  * any 型のプロパティは除外せず保持する。
  */
 type DataKeys<T> = {
-  [K in keyof T & string]: IsAny<T[K]> extends true ? K : T[K] extends (...args: any[]) => any ? never : K;
+  [K in keyof T & string]:
+    K extends `$${string}` ? never :
+    IsAny<T[K]> extends true ? K : T[K] extends (...args: any[]) => any ? never : K;
 }[keyof T & string];
 
 // ============================================================
@@ -160,14 +163,17 @@ export interface WcsStateApi {
   /**
    * ワイルドカードを含むパスにマッチする全要素を配列で取得する。
    *
+   * @param path - ワイルドカードを含むパス
+   * @param indexes - 各ワイルドカード階層のインデックス（省略時はループコンテキストから解決）
+   *
    * @example
    * ```ts
    * get "cart.totalPrice"() {
-   *   return this.$getAll("cart.items.*.price", []).reduce((sum, v) => sum + v, 0);
+   *   return this.$getAll("cart.items.*.price").reduce((sum, v) => sum + v, 0);
    * }
    * ```
    */
-  $getAll<V = any>(path: string, defaultValue?: V[]): V[];
+  $getAll<V = any>(path: string, indexes?: number[]): V[];
 
   /**
    * 指定パスの更新を手動でトリガーする。
@@ -193,9 +199,28 @@ export interface WcsStateApi {
   /** `<wcs-state>` 要素への参照 */
   readonly $stateElement: HTMLElement;
 
+  /**
+   * `$commandTokens` で宣言した command token の名前空間。
+   * `this.$command.<name>` で token を解決できる（バインディングでは
+   * `onclick: $command.<name>` / `command.<method>: $command.<name>`）。
+   */
+  readonly $command: Record<string, { emit(...args: any[]): any }>;
+
+  /** `$streams` 各エントリの状態（"idle" | "active" | "done" | "error"）を返す読み取り専用名前空間 */
+  readonly $streamStatus: Record<string, "idle" | "active" | "done" | "error">;
+
+  /** `$streams` 各エントリの直近エラーを返す読み取り専用名前空間 */
+  readonly $streamError: Record<string, unknown>;
+
+  // computed getter 内での依存追跡付き読み取りの正規形は dotted パス
+  // （`this["$streamStatus.<name>"]` — docs/state-streams-design.md §4-3）
+  readonly [key: `$streamStatus.${string}`]: "idle" | "active" | "done" | "error";
+  readonly [key: `$streamError.${string}`]: unknown;
+
   // ループインデックス変数 ($1〜$9)
   // for テンプレート内のイベントハンドラで、ネストされたループの
   // 各階層のインデックスにアクセスするために使用。
+  // （ランタイムは $1〜$128 まで解決するが、型宣言は実用域の $9 までとする）
   readonly $1: number;
   readonly $2: number;
   readonly $3: number;
@@ -227,7 +252,7 @@ export interface WcsStateApi {
  *   increment() {
  *     this.count++;                // number
  *     this["users.*.name"];        // string (パス型解決)
- *     this.$getAll("path", []);    // API
+ *     this.$getAll("users.*.age"); // API
  *   }
  * });
  * ```

--- a/packages/state/src/manifest.ts
+++ b/packages/state/src/manifest.ts
@@ -32,6 +32,9 @@ import {
   STATE_COMMAND_NAMESPACE_NAME,
   STATE_EVENT_TOKENS_NAME,
   STATE_ON_NAME,
+  STATE_STREAMS_NAME,
+  STATE_STREAM_STATUS_NAMESPACE_NAME,
+  STATE_STREAM_ERROR_NAMESPACE_NAME,
 } from "./define.js";
 
 // 消費側（vscode-wcs 等）が `@wcstack/state/manifest` から正本を直接引けるよう再エクスポート。
@@ -108,6 +111,9 @@ export function getWcsManifest(): IWcsManifest {
       STATE_COMMAND_NAMESPACE_NAME,
       STATE_EVENT_TOKENS_NAME,
       STATE_ON_NAME,
+      STATE_STREAMS_NAME,
+      STATE_STREAM_STATUS_NAMESPACE_NAME,
+      STATE_STREAM_ERROR_NAMESPACE_NAME,
     ],
   };
 }

--- a/packages/state/src/proxy/traps/get.ts
+++ b/packages/state/src/proxy/traps/get.ts
@@ -4,15 +4,16 @@
  * StateClassのProxyトラップとして、プロパティアクセス時の値取得処理を担う関数（get）の実装です。
  *
  * 主な役割:
- * - 文字列プロパティの場合、特殊プロパティ（$1〜$9, $resolve, $getAll, $navigate）に応じた値やAPIを返却
+ * - 文字列プロパティの場合、特殊プロパティ（$1〜、$stateElement, $getAll, $postUpdate,
+ *   $resolve, $trackDependency, $command, $streamStatus, $streamError）に応じた値やAPIを返却
  * - 通常のプロパティはgetResolvedPathInfoでパス情報を解決し、getListIndexでリストインデックスを取得
  * - getByRefで構造化パス・リストインデックスに対応した値を取得
  * - シンボルプロパティの場合はhandler.callableApi経由でAPIを呼び出し
  * - それ以外はReflect.getで通常のプロパティアクセスを実行
  *
  * 設計ポイント:
- * - $1〜$9は直近のStatePropertyRefのリストインデックス値を返す特殊プロパティ
- * - $resolve, $getAll, $navigateはAPI関数やルーターインスタンスを返す
+ * - $1〜$128（MAX_WILDCARD_DEPTH）は直近のStatePropertyRefのリストインデックス値を返す特殊プロパティ
+ * - $getAll, $resolve 等はAPI関数を、$command / $streamStatus / $streamError は名前空間を返す
  * - 通常のプロパティアクセスもバインディングや多重ループに対応
  * - シンボルAPIやReflect.getで拡張性・互換性も確保
  */

--- a/packages/vscode-wcs/CHANGELOG.md
+++ b/packages/vscode-wcs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.10.0
+
+`@wcstack/state` の現行実装（command-token / event-token / spread / `$streams`）への追従。
+
+### Features
+
+- **`$streams` 宣言対応** — エントリ名を値プロパティとして実体化（`initial` から型・配列パスを導出）し、`$streamStatus.<name>` / `$streamError.<name>` を補完・検証対象に追加
+- **command-token 対応** — `$commandTokens` 宣言から `$command.<name>` 候補を導出。`onclick: $command.<name>` / `command.<method>: $command.<name>` の右辺を宣言と照合
+- **event-token 対応** — `$eventTokens` 宣言からトークン名候補を導出。`eventToken.<prop>: <name>` の右辺を宣言と照合（state パスとしては検証しない）
+- **スプレッド / radio / checkbox** — `...:` のフィルタ禁止・ターゲット必須をランタイムと同じく error 化。`...` / `radio` / `checkbox` / `command.` / `eventToken.` を補完候補に追加
+- **prop 側 input フィルタ** — `value|int: path` の書き戻しフィルタを解釈し、フィルタ名・引数を検証
+- **修飾子 `ro`** — 双方向バインディングの書き戻し抑止修飾子を補完候補に追加
+- **ループインデックス** — `$1` 等を存在検証から除外し、`<template for>` 外での使用に warning を追加
+
+### Fixes
+
+- トップレベルの `$` 予約キー（`$streams` / `$commandTokens` / `$eventTokens` / `$on` / `$bindables` / ライフサイクル）が偽のデータパス（`streams` 等）として補完・検証に混入していた問題を修正
+- preamble の `$getAll` シグネチャをランタイム実装 `(path, indexes?)` に修正（旧: `(path, defaultValue?)`）
+- preamble に `$command` / `$streamStatus` / `$streamError` 名前空間と `this["$streamStatus.<name>"]` の dotted アクセス型を追加（`$streams` 利用スクリプトの偽型エラーを解消）
+
 ## 0.1.0
 
 Initial release.

--- a/packages/vscode-wcs/README.ja.md
+++ b/packages/vscode-wcs/README.ja.md
@@ -19,7 +19,7 @@ export default {
     this.count++;              // number
     this["users.*.name"];      // string
     this["users.*.age"];       // number
-    this.$getAll("path", []);  // WcsStateApi
+    this.$getAll("users.*.age"); // WcsStateApi
   },
 
   get "users.*.ageCategory"() {
@@ -37,9 +37,11 @@ export default {
 - `data-wcs="` → `textContent`, `class.`, `style.`, `onclick`, `for`, `if` ...
 - `data-wcs="textContent: ` → `count`, `users`, `users.*.name` ...
 - `data-wcs="textContent: count|` → `gt`, `eq`, `uc`, `trim` ...
-- `data-wcs="onclick#` → `prevent`, `stop`
+- `data-wcs="onclick#` → `prevent`, `stop`, `ro`
 - `data-wcs="for: ` → 配列型のパスのみ表示
-- `data-wcs="onclick: ` → メソッドのみ表示
+- `data-wcs="onclick: ` → メソッドと `$command.<name>` のみ表示
+- `data-wcs="command.play: ` → `$command.<name>`（`$commandTokens` 宣言由来）のみ表示
+- `data-wcs="eventToken.value: ` → `$eventTokens` 宣言のトークン名のみ表示
 
 #### for コンテキスト補完
 

--- a/packages/vscode-wcs/README.md
+++ b/packages/vscode-wcs/README.md
@@ -19,7 +19,7 @@ export default {
     this.count++;              // number
     this["users.*.name"];      // string
     this["users.*.age"];       // number
-    this.$getAll("path", []);  // WcsStateApi
+    this.$getAll("users.*.age"); // WcsStateApi
   },
 
   get "users.*.ageCategory"() {
@@ -37,9 +37,11 @@ Completions for property names, state paths, and filter names in `data-wcs` attr
 - `data-wcs="` → `textContent`, `class.`, `style.`, `onclick`, `for`, `if` ...
 - `data-wcs="textContent: ` → `count`, `users`, `users.*.name` ...
 - `data-wcs="textContent: count|` → `gt`, `eq`, `uc`, `trim` ...
-- `data-wcs="onclick#` → `prevent`, `stop`
+- `data-wcs="onclick#` → `prevent`, `stop`, `ro`
 - `data-wcs="for: ` → only array-typed paths
-- `data-wcs="onclick: ` → only methods
+- `data-wcs="onclick: ` → only methods and `$command.<name>`
+- `data-wcs="command.play: ` → only `$command.<name>` (from the `$commandTokens` declaration)
+- `data-wcs="eventToken.value: ` → only token names from the `$eventTokens` declaration
 
 #### for-context Completions
 

--- a/packages/vscode-wcs/__tests__/bindingValidator.test.ts
+++ b/packages/vscode-wcs/__tests__/bindingValidator.test.ts
@@ -557,3 +557,161 @@ export default { count: 0 };
     expect(diags.some(d => d.message.includes('"missing"'))).toBe(true);
   });
 });
+
+describe('validateBindings — command-token / event-token / $streams / spread', () => {
+  const TOKEN_STATE = `
+<wcs-state>
+  <script type="module">
+export default {
+  count: 0,
+  items: [],
+  $commandTokens: ["play", "pause"],
+  $eventTokens: ["userChanged"],
+  $streams: {
+    metrics: { source(a, s) { return x; }, initial: [] },
+  },
+};
+  </script>
+</wcs-state>`;
+
+  it('onclick: $command.<宣言済み> に警告を出さない', () => {
+    const html = `${TOKEN_STATE}\n<button data-wcs="onclick: $command.play"></button>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('onclick: $command.<未宣言> に warning を出す', () => {
+    const html = `${TOKEN_STATE}\n<button data-wcs="onclick: $command.typo"></button>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('$commandTokens に宣言されていません');
+  });
+
+  it('command.<method>: $command.<宣言済み> に警告を出さない', () => {
+    const html = `${TOKEN_STATE}\n<audio data-wcs="command.play: $command.play"></audio>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('command.<method> の右辺が $command.* でないと warning を出す', () => {
+    const html = `${TOKEN_STATE}\n<audio data-wcs="command.play: count"></audio>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('$command.<name>');
+  });
+
+  it('eventToken.<prop>: <宣言済みトークン> に警告を出さない', () => {
+    const html = `${TOKEN_STATE}\n<my-input data-wcs="eventToken.value: userChanged"></my-input>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('eventToken.<prop>: <未宣言トークン> に warning を出す', () => {
+    const html = `${TOKEN_STATE}\n<my-input data-wcs="eventToken.value: typo"></my-input>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('$eventTokens に宣言されていません');
+  });
+
+  it('$eventTokens 宣言がない場合は eventToken の右辺を検証しない（誤警告回避）', () => {
+    const html = `
+<wcs-state>
+  <script type="module">
+export default { count: 0 };
+  </script>
+</wcs-state>
+<my-input data-wcs="eventToken.value: anything"></my-input>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('$streamStatus.<宣言済み> のバインディングに警告を出さない', () => {
+    const html = `${TOKEN_STATE}\n<span data-wcs="textContent: $streamStatus.metrics"></span>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('$streamStatus.<未宣言> に warning を出す', () => {
+    const html = `${TOKEN_STATE}\n<span data-wcs="textContent: $streamStatus.typo"></span>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('$streams 宣言に存在しません');
+  });
+
+  it('$streams 宣言がない場合は $streamStatus.* を検証しない（誤警告回避）', () => {
+    const html = `
+<wcs-state>
+  <script type="module">
+export default { count: 0 };
+  </script>
+</wcs-state>
+<span data-wcs="textContent: $streamStatus.metrics"></span>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('$streams の値プロパティを for: にバインドしても警告を出さない', () => {
+    const html = `${TOKEN_STATE}\n<template data-wcs="for: metrics"><span data-wcs="textContent: .*"></span></template>`;
+    const diags = validateBindings(html, 'data-wcs');
+    const forDiags = diags.filter(d => d.message.includes('"metrics"'));
+    expect(forDiags).toHaveLength(0);
+  });
+
+  it('スプレッドのターゲットにフィルタがあると error を出す', () => {
+    const html = `${TOKEN_STATE}\n<wcs-fetch data-wcs="...: count|uc"></wcs-fetch>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags.some(d => d.severity === 'error' && d.message.includes('スプレッド'))).toBe(true);
+  });
+
+  it('スプレッドのターゲットパスがないと error を出す', () => {
+    const html = `${TOKEN_STATE}\n<wcs-fetch data-wcs="...:"></wcs-fetch>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags.some(d => d.severity === 'error' && d.message.includes('ターゲットパスが必要'))).toBe(true);
+  });
+
+  it('正常なスプレッドには警告を出さない', () => {
+    const html = `${TOKEN_STATE}\n<wcs-fetch data-wcs="...: count"></wcs-fetch>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+});
+
+describe('validateBindings — prop 側 input フィルタ / ループインデックス', () => {
+  const STATE = `
+<wcs-state>
+  <script type="module">
+export default { count: 0, name: "a", items: [{ label: "x" }] };
+  </script>
+</wcs-state>`;
+
+  it('prop 側の既知 input フィルタには警告を出さない', () => {
+    const html = `${STATE}\n<input data-wcs="value|int: count">`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('prop 側の未知 input フィルタに warning を出す', () => {
+    const html = `${STATE}\n<input data-wcs="value|nosuch: name">`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags.some(d => d.message.includes('"nosuch"'))).toBe(true);
+  });
+
+  it('prop 側フィルタがあってもプロパティ名・パスは正しく検証される', () => {
+    const html = `${STATE}\n<input data-wcs="value|int: missing">`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags.some(d => d.message.includes('"missing"'))).toBe(true);
+  });
+
+  it('for 内の $1 には警告を出さない', () => {
+    const html = `${STATE}\n<template data-wcs="for: items"><span data-wcs="textContent: $1"></span></template>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(0);
+  });
+
+  it('for 外の $1 に warning を出す', () => {
+    const html = `${STATE}\n<span data-wcs="textContent: $1"></span>`;
+    const diags = validateBindings(html, 'data-wcs');
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain('ループインデックス');
+  });
+});

--- a/packages/vscode-wcs/__tests__/preamble.test.ts
+++ b/packages/vscode-wcs/__tests__/preamble.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { WCS_PREAMBLE } from '../src/language/preamble';
+
+/**
+ * preamble は仮想 TypeScript ドキュメントの先頭に注入される文字列なので、
+ * ビルドでは型検査されない。ここで実際に TypeScript コンパイラに通して
+ * 「preamble 自体が валид」「想定ユースケースが型エラーにならない」ことを保証する。
+ */
+function typecheck(userCode: string): readonly ts.Diagnostic[] {
+  const fileName = 'virtual.ts';
+  const source = WCS_PREAMBLE + userCode;
+  const options: ts.CompilerOptions = {
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+    noEmit: true,
+  };
+  const host = ts.createCompilerHost(options);
+  const origGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, languageVersion, ...rest) =>
+    name === fileName
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : origGetSourceFile(name, languageVersion, ...rest);
+  const program = ts.createProgram([fileName], options, host);
+  return ts.getPreEmitDiagnostics(program).filter(d => d.file?.fileName === fileName);
+}
+
+function messages(diags: readonly ts.Diagnostic[]): string[] {
+  return diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
+}
+
+describe('WCS_PREAMBLE の型検査', () => {
+  it('preamble 単体が型エラーなくコンパイルできる', () => {
+    const diags = typecheck('');
+    expect(messages(diags)).toEqual([]);
+  });
+
+  it('基本的な defineState の利用が型エラーにならない', () => {
+    const diags = typecheck(`
+defineState({
+  count: 0,
+  users: [] as { name: string; age: number }[],
+  increment() {
+    this.count++;
+    const name: string = this["users.*.name"];
+    void name;
+  },
+});
+`);
+    expect(messages(diags)).toEqual([]);
+  });
+
+  it('$getAll は (path, indexes?) シグネチャ（ランタイム getAll.ts と一致）', () => {
+    const diags = typecheck(`
+defineState({
+  items: [] as { price: number }[],
+  sum: 0,
+  recalc() {
+    this.sum = this.$getAll("items.*.price").length + this.$getAll("items.*.price", [0]).length;
+  },
+});
+`);
+    expect(messages(diags)).toEqual([]);
+  });
+
+  it('$command / $streamStatus / $streamError 名前空間にアクセスできる', () => {
+    const diags = typecheck(`
+defineState({
+  filter: "all",
+  $commandTokens: ["play"],
+  $streams: {
+    metrics: {
+      source: (_args: unknown, _signal: AbortSignal) => (async function* () { yield 1; })(),
+      initial: [] as number[],
+    },
+  },
+  handle() {
+    this.$command.play.emit();
+    const st: "idle" | "active" | "done" | "error" = this["$streamStatus.metrics"];
+    const err: unknown = this["$streamError.metrics"];
+    const st2 = this.$streamStatus.metrics;
+    void st; void err; void st2;
+  },
+});
+`);
+    expect(messages(diags)).toEqual([]);
+  });
+
+  it('$ 予約キーはドットパスアクセサに含まれない（$streams.metrics は型エラー）', () => {
+    const diags = typecheck(`
+defineState({
+  $streams: {
+    metrics: { source: () => (async function* () { yield 1; })(), initial: 0 },
+  },
+  handle() {
+    this["$streams.metrics"];
+  },
+});
+`);
+    expect(diags.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/vscode-wcs/__tests__/stateAnalyzer.test.ts
+++ b/packages/vscode-wcs/__tests__/stateAnalyzer.test.ts
@@ -233,3 +233,118 @@ describe('analyzeJsonPaths', () => {
     expect(paths.map(p => p.path)).not.toContain('a.b.c.d.e.f.g.h');
   });
 });
+
+describe('analyzeStatePaths — $ 予約キー（@wcstack/state define.ts の予約名）', () => {
+  const STREAMS_SCRIPT = `
+export default {
+  filter: "all",
+  $streams: {
+    metrics: {
+      args() { return this.filter; },
+      async *source(args, signal) { yield 1; },
+      fold(acc, chunk) { return [...acc, chunk]; },
+      initial: [],
+    },
+    latestPrice: {
+      source(args, signal) { return makeStream(); },
+    },
+  },
+};`;
+
+  it('$streams のエントリ名を値プロパティとして実体化する', () => {
+    const paths = analyzeStatePaths(STREAMS_SCRIPT);
+    const metrics = paths.find(p => p.path === 'metrics');
+    expect(metrics).toBeDefined();
+    expect(metrics!.kind).toBe('data');
+    expect(paths.find(p => p.path === 'latestPrice')).toBeDefined();
+  });
+
+  it('$streams エントリの initial から型ヒント・配列パスを導出する', () => {
+    const paths = analyzeStatePaths(STREAMS_SCRIPT);
+    expect(paths.find(p => p.path === 'metrics')?.typeHint).toBe('array');
+    expect(paths.map(p => p.path)).toContain('metrics.*');
+    expect(paths.map(p => p.path)).toContain('metrics.length');
+  });
+
+  it('$streamStatus / $streamError の名前空間パスを生成する', () => {
+    const paths = analyzeStatePaths(STREAMS_SCRIPT);
+    expect(paths.find(p => p.path === '$streamStatus.metrics')?.typeHint).toBe('string');
+    expect(paths.map(p => p.path)).toContain('$streamError.metrics');
+    expect(paths.map(p => p.path)).toContain('$streamStatus.latestPrice');
+  });
+
+  it('$streams 自体や宣言オブジェクトの中身はパスにしない', () => {
+    const paths = analyzeStatePaths(STREAMS_SCRIPT);
+    const pathNames = paths.map(p => p.path);
+    expect(pathNames).not.toContain('$streams');
+    expect(pathNames).not.toContain('streams');
+    expect(pathNames).not.toContain('$streams.metrics');
+    expect(pathNames).not.toContain('$streams.metrics.initial');
+  });
+
+  it('明示宣言された同名プロパティが $streams の実体化より優先される', () => {
+    const paths = analyzeStatePaths(`
+export default {
+  metrics: "explicit",
+  $streams: {
+    metrics: { source(a, s) { return x; }, initial: [] },
+  },
+};`);
+    const metrics = paths.filter(p => p.path === 'metrics');
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].typeHint).toBe('string');
+  });
+
+  it('$commandTokens から $command.<name> 候補を生成する', () => {
+    const paths = analyzeStatePaths(`
+export default {
+  $commandTokens: ["play", "pause"],
+};`);
+    const play = paths.find(p => p.path === '$command.play');
+    expect(play).toBeDefined();
+    expect(play!.kind).toBe('command');
+    expect(paths.find(p => p.path === '$command.pause')).toBeDefined();
+    expect(paths.map(p => p.path)).not.toContain('$commandTokens');
+    expect(paths.map(p => p.path)).not.toContain('commandTokens');
+  });
+
+  it('$eventTokens からトークン名候補を生成する', () => {
+    const paths = analyzeStatePaths(`
+export default {
+  $eventTokens: ["userChanged"],
+};`);
+    const token = paths.find(p => p.path === 'userChanged');
+    expect(token).toBeDefined();
+    expect(token!.kind).toBe('eventToken');
+    expect(paths.map(p => p.path)).not.toContain('$eventTokens');
+  });
+
+  it('$on / $bindables / ライフサイクルフックはパスにしない', () => {
+    const paths = analyzeStatePaths(`
+export default {
+  count: 0,
+  $on: {
+    userChanged(state, event) {},
+  },
+  $bindables: ["count"],
+  async $connectedCallback() { this.count = 1; },
+  $updatedCallback() {},
+};`);
+    const pathNames = paths.map(p => p.path);
+    expect(pathNames).toContain('count');
+    expect(pathNames).not.toContain('$on');
+    expect(pathNames).not.toContain('on');
+    expect(pathNames).not.toContain('$bindables');
+    expect(pathNames).not.toContain('$connectedCallback');
+    expect(pathNames).not.toContain('connectedCallback');
+    expect(pathNames).not.toContain('$updatedCallback');
+  });
+
+  it('JSON のトップレベル $ キーはパスにしない', () => {
+    const paths = analyzeJsonPaths('{"count": 0, "$streams": {"metrics": {}}}');
+    const pathNames = paths.map(p => p.path);
+    expect(pathNames).toContain('count');
+    expect(pathNames).not.toContain('$streams');
+    expect(pathNames).not.toContain('$streams.metrics');
+  });
+});

--- a/packages/vscode-wcs/package.json
+++ b/packages/vscode-wcs/package.json
@@ -2,7 +2,7 @@
   "name": "wcstack-intellisense",
   "displayName": "WcStack IntelliSense",
   "description": "TypeScript language features for <wcs-state> inline scripts in HTML",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "publisher": "wcstack",
   "license": "MIT",
   "type": "module",

--- a/packages/vscode-wcs/src/language/preamble.ts
+++ b/packages/vscode-wcs/src/language/preamble.ts
@@ -21,7 +21,9 @@ type _IsPlainObject<T> =
     ? false
     : T extends Record<string, any> ? true : false;
 type _DataKeys<T> = {
-  [K in keyof T & string]: _IsAny<T[K]> extends true ? K : T[K] extends Function ? never : K;
+  [K in keyof T & string]:
+    K extends \`$\${string}\` ? never :
+    _IsAny<T[K]> extends true ? K : T[K] extends Function ? never : K;
 }[keyof T & string];
 type _WcsPaths<T, D extends readonly any[] = []> =
   D["length"] extends 4 ? never :
@@ -49,12 +51,18 @@ type _WcsPathValue<T, P extends string> =
       : never
     : never;
 type _WcsPathAccessor<T> = { [P in _WcsPaths<T>]: _WcsPathValue<T, P> };
+type _WcsStreamStatus = "idle" | "active" | "done" | "error";
 interface WcsStateApi {
-  $getAll<V = any>(path: string, defaultValue?: V[]): V[];
+  $getAll<V = any>(path: string, indexes?: number[]): V[];
   $postUpdate(path: string): void;
   $resolve(path: string, indexes: number[], value?: any): any;
   $trackDependency(path: string): void;
   readonly $stateElement: HTMLElement;
+  readonly $command: Record<string, { emit(...args: any[]): any }>;
+  readonly $streamStatus: Record<string, _WcsStreamStatus>;
+  readonly $streamError: Record<string, unknown>;
+  readonly [key: \`$streamStatus.\${string}\`]: _WcsStreamStatus;
+  readonly [key: \`$streamError.\${string}\`]: unknown;
   readonly $1: number; readonly $2: number; readonly $3: number;
   readonly $4: number; readonly $5: number; readonly $6: number;
   readonly $7: number; readonly $8: number; readonly $9: number;

--- a/packages/vscode-wcs/src/service/bindingValidator.ts
+++ b/packages/vscode-wcs/src/service/bindingValidator.ts
@@ -64,6 +64,80 @@ export function validateBindings(html: string, attrName: string, stateTagName: s
       // パス検証（targetState でスコープ）
       const scopedPaths = pathsByState.get(parsed.targetState) ?? [];
       const scopedPathSet = new Set(scopedPaths.map(p => p.path));
+      const propNoMod = parsed.property.replace(/#.*$/, '').trim();
+
+      // スプレッド `...: target` — フィルタ禁止・ターゲット必須（parseBindTextsForElement.ts と対応）。
+      // ターゲット自体は通常の state パスなので、存在検証は共通ロジックに流す。
+      if (propNoMod === '...') {
+        for (const filter of parsed.filters) {
+          diagnostics.push({
+            start: bindingStart + filter.offset,
+            end: bindingStart + filter.offset + filter.name.length,
+            message: `スプレッドのターゲットにフィルタは使用できません`,
+            severity: 'error',
+          });
+        }
+        if (!parsed.path || parsed.path.trim() === '') {
+          diagnostics.push({
+            start: bindingStart,
+            end: bindingStart + binding.length,
+            message: `スプレッドにはターゲットパスが必要です`,
+            severity: 'error',
+          });
+        }
+      }
+
+      // event-token バインディング `eventToken.<prop>: <tokenName>` — 右辺は state パスではなく
+      // $eventTokens 宣言名（eventTokenHandler.ts）。トークン名の検証のみ行い、以降はスキップ。
+      if (propNoMod.startsWith('eventToken.')) {
+        const tokenNames = new Set(
+          scopedPaths.filter(p => p.kind === 'eventToken').map(p => p.path),
+        );
+        const tokenName = parsed.path?.trim() ?? '';
+        if (tokenName && tokenNames.size > 0 && !tokenNames.has(tokenName)) {
+          const pathOffset = binding.indexOf(parsed.path!);
+          const pathStart = bindingStart + pathOffset;
+          diagnostics.push({
+            start: pathStart,
+            end: pathStart + tokenName.length,
+            message: `イベントトークン "${tokenName}" は $eventTokens に宣言されていません`,
+            severity: 'warning',
+          });
+        }
+        pos += binding.length + 1;
+        continue;
+      }
+
+      // command-token バインディング `command.<method>: $command.<name>`（applyChangeToCommand.ts）。
+      // 右辺の検証のみ行い、以降はスキップ。
+      const commandNames = new Set(
+        scopedPaths.filter(p => p.kind === 'command').map(p => p.path),
+      );
+      if (propNoMod.startsWith('command.')) {
+        const tokenPath = parsed.path?.trim() ?? '';
+        if (tokenPath) {
+          const pathOffset = binding.indexOf(parsed.path!);
+          const pathStart = bindingStart + pathOffset;
+          if (!tokenPath.startsWith('$command.')) {
+            diagnostics.push({
+              start: pathStart,
+              end: pathStart + tokenPath.length,
+              message: `command バインディングの右辺には $command.<name>（$commandTokens で宣言）を指定してください`,
+              severity: 'warning',
+            });
+          } else if (commandNames.size > 0 && !commandNames.has(tokenPath)) {
+            diagnostics.push({
+              start: pathStart,
+              end: pathStart + tokenPath.length,
+              message: `コマンドトークン "${tokenPath}" は $commandTokens に宣言されていません`,
+              severity: 'warning',
+            });
+          }
+        }
+        pos += binding.length + 1;
+        continue;
+      }
+
       if (parsed.path && scopedPaths.length > 0) {
         const pathTrimmed = parsed.path.trim();
         if (pathTrimmed && !isLiteral(pathTrimmed)) {
@@ -77,15 +151,18 @@ export function validateBindings(html: string, attrName: string, stateTagName: s
               checkPath = ''; // 展開できない場合はスキップ
             }
           }
-          if (checkPath && !isValidPath(checkPath, scopedPathSet)) {
-            const pathOffset = binding.indexOf(parsed.path);
-            const pathStart = bindingStart + pathOffset;
-            diagnostics.push({
-              start: pathStart,
-              end: pathStart + pathTrimmed.length,
-              message: `パス "${pathTrimmed}" は状態定義に存在しません${pathTrimmed.startsWith('.') ? `（展開: ${checkPath}）` : ''}`,
-              severity: 'warning',
-            });
+          if (checkPath) {
+            const message = validatePathExistence(checkPath, pathTrimmed, scopedPaths, scopedPathSet, commandNames);
+            if (message) {
+              const pathOffset = binding.indexOf(parsed.path);
+              const pathStart = bindingStart + pathOffset;
+              diagnostics.push({
+                start: pathStart,
+                end: pathStart + pathTrimmed.length,
+                message: `${message}${pathTrimmed.startsWith('.') ? `（展開: ${checkPath}）` : ''}`,
+                severity: 'warning',
+              });
+            }
           }
         }
       }
@@ -121,6 +198,18 @@ export function validateBindings(html: string, attrName: string, stateTagName: s
             });
           }
 
+          // for 外でループインデックス（$1〜）を使用
+          if (!insideFor && /^\$\d+$/.test(pathTrimmed)) {
+            const pathOffset = binding.indexOf(parsed.path);
+            const pathStart = bindingStart + pathOffset;
+            diagnostics.push({
+              start: pathStart,
+              end: pathStart + pathTrimmed.length,
+              message: `ループインデックス "${pathTrimmed}" は <template for> の外側では使用できません`,
+              severity: 'warning',
+            });
+          }
+
           // UI で解決済みパス（数値セグメントを含む）を使用
           if (/\.\d+\.|\.\d+$/.test(pathTrimmed)) {
             const pathOffset = binding.indexOf(parsed.path);
@@ -136,7 +225,9 @@ export function validateBindings(html: string, attrName: string, stateTagName: s
       }
 
       // フィルタ検証
-      if (parsed.property.startsWith('on') && parsed.filters.length > 0) {
+      if (propNoMod === '...') {
+        // スプレッドのフィルタ違反は上で error として報告済み
+      } else if (parsed.property.startsWith('on') && parsed.filters.length > 0) {
         // イベントハンドラにフィルタは使用不可
         for (const filter of parsed.filters) {
           diagnostics.push({
@@ -148,51 +239,7 @@ export function validateBindings(html: string, attrName: string, stateTagName: s
         }
       } else {
         for (const filter of parsed.filters) {
-          const info = filterMap.get(filter.name);
-          if (!info) {
-            diagnostics.push({
-              start: bindingStart + filter.offset,
-              end: bindingStart + filter.offset + filter.name.length,
-              message: `フィルタ "${filter.name}" は組み込みフィルタに存在しません`,
-              severity: 'warning',
-            });
-            continue;
-          }
-
-          // 引数の個数チェック
-          const argCount = filter.args.length;
-          if (argCount < info.minArgs) {
-            diagnostics.push({
-              start: bindingStart + filter.offset,
-              end: bindingStart + filter.offset + filter.name.length,
-              message: `フィルタ "${filter.name}" には最低 ${info.minArgs} 個の引数が必要です（${argCount} 個指定）`,
-              severity: 'error',
-            });
-          } else if (argCount > info.maxArgs) {
-            diagnostics.push({
-              start: bindingStart + filter.offset,
-              end: bindingStart + filter.offset + filter.name.length,
-              message: `フィルタ "${filter.name}" の引数は最大 ${info.maxArgs} 個です（${argCount} 個指定）`,
-              severity: 'error',
-            });
-          }
-
-          // 引数の型チェック
-          if (info.argTypes && argCount > 0) {
-            for (let i = 0; i < Math.min(argCount, info.argTypes.length); i++) {
-              const expectedArgType = info.argTypes[i];
-              if (expectedArgType === 'any') continue;
-              const actualArgType = inferArgType(filter.args[i]);
-              if (actualArgType !== expectedArgType) {
-                diagnostics.push({
-                  start: bindingStart + filter.argsOffset,
-                  end: bindingStart + filter.argsOffset + filter.name.length,
-                  message: `フィルタ "${filter.name}" の第${i + 1}引数は ${expectedArgType} 型が必要です（"${filter.args[i]}" は ${actualArgType} 型）`,
-                  severity: 'warning',
-                });
-              }
-            }
-          }
+          diagnostics.push(...validateFilterUsage(filter, bindingStart));
         }
 
         // フィルタ間の入力型チェック
@@ -205,6 +252,12 @@ export function validateBindings(html: string, attrName: string, stateTagName: s
             diagnostics.push(...chainDiags);
           }
         }
+      }
+
+      // prop 側 input フィルタの検証（two-way の書き戻し方向。
+      // ランタイムの input / output フィルタ集合は同一 — filters/builtinFilters.ts）
+      for (const filter of parsed.inputFilters) {
+        diagnostics.push(...validateFilterUsage(filter, bindingStart));
       }
 
       // プロパティに応じた型チェック
@@ -256,6 +309,8 @@ interface ParsedBinding {
   path: string | null;
   targetState: string;
   filters: ParsedFilter[];
+  /** prop 側の input フィルタ（`value|number: path` — 書き戻し方向に適用） */
+  inputFilters: ParsedFilter[];
 }
 
 /**
@@ -312,10 +367,15 @@ function parseBindingExpression(expr: string): ParsedBinding {
 
   if (colonIndex === -1) {
     // else ディレクティブなど（パスなし）
-    return { property: expr.trim(), path: null, targetState: 'default', filters: [] };
+    return { property: expr.trim(), path: null, targetState: 'default', filters: [], inputFilters: [] };
   }
 
-  const property = expr.slice(0, colonIndex).trim();
+  // prop 側の input フィルタを分離（`value|number: path` — parsePropPart.ts と対応）
+  const rawProp = expr.slice(0, colonIndex);
+  const propSegments = splitByPipe(rawProp);
+  const property = propSegments[0].trim();
+  const inputFilters = parseFilterSegments(expr, propSegments.slice(1), propSegments[0].length + 1);
+
   const afterColon = expr.slice(colonIndex + 1);
 
   // フィルタを分離（括弧内の `|` はスキップ）
@@ -329,10 +389,23 @@ function parseBindingExpression(expr: string): ParsedBinding {
   const targetState = atIndex !== -1 ? pathSegment.slice(atIndex + 1).trim() || 'default' : 'default';
 
   // フィルタ名・引数・オフセットを抽出
-  const filters: ParsedFilter[] = [];
-  let filterSearchStart = colonIndex + 1 + pathSegment.length + 1; // +1 for first '|'
+  const filters = parseFilterSegments(expr, filterSegments, colonIndex + 1 + pathSegment.length + 1);
 
-  for (const seg of filterSegments) {
+  return { property, path: path.trim() || null, targetState, filters, inputFilters };
+}
+
+/**
+ * `|` 分割済みのフィルタセグメント列から名前・引数・オフセットを抽出する。
+ *
+ * @param expr - バインディング式全体（オフセット計算の基準）
+ * @param segments - フィルタセグメント（先頭の prop/path セグメントを除いたもの）
+ * @param searchStart - 最初のセグメントの expr 内開始位置
+ */
+function parseFilterSegments(expr: string, segments: string[], searchStart: number): ParsedFilter[] {
+  const filters: ParsedFilter[] = [];
+  let filterSearchStart = searchStart;
+
+  for (const seg of segments) {
     const trimmed = seg.trim();
     const filterMatch = trimmed.match(/^(\w+)(?:\(([^)]*)\))?/);
     if (filterMatch) {
@@ -350,7 +423,61 @@ function parseBindingExpression(expr: string): ParsedBinding {
     filterSearchStart += seg.length + 1; // +1 for '|'
   }
 
-  return { property, path: path.trim() || null, targetState, filters };
+  return filters;
+}
+
+/**
+ * フィルタ1件の名前・引数個数・引数型を検証する（input / output 共通）。
+ */
+function validateFilterUsage(filter: ParsedFilter, bindingStart: number): BindingDiagnostic[] {
+  const diagnostics: BindingDiagnostic[] = [];
+  const info = filterMap.get(filter.name);
+  if (!info) {
+    diagnostics.push({
+      start: bindingStart + filter.offset,
+      end: bindingStart + filter.offset + filter.name.length,
+      message: `フィルタ "${filter.name}" は組み込みフィルタに存在しません`,
+      severity: 'warning',
+    });
+    return diagnostics;
+  }
+
+  // 引数の個数チェック
+  const argCount = filter.args.length;
+  if (argCount < info.minArgs) {
+    diagnostics.push({
+      start: bindingStart + filter.offset,
+      end: bindingStart + filter.offset + filter.name.length,
+      message: `フィルタ "${filter.name}" には最低 ${info.minArgs} 個の引数が必要です（${argCount} 個指定）`,
+      severity: 'error',
+    });
+  } else if (argCount > info.maxArgs) {
+    diagnostics.push({
+      start: bindingStart + filter.offset,
+      end: bindingStart + filter.offset + filter.name.length,
+      message: `フィルタ "${filter.name}" の引数は最大 ${info.maxArgs} 個です（${argCount} 個指定）`,
+      severity: 'error',
+    });
+  }
+
+  // 引数の型チェック
+  if (info.argTypes && argCount > 0) {
+    for (let i = 0; i < Math.min(argCount, info.argTypes.length); i++) {
+      const expectedArgType = info.argTypes[i];
+      if (expectedArgType === 'any') continue;
+      const actualArgType = inferArgType(filter.args[i]);
+      if (actualArgType !== expectedArgType) {
+        diagnostics.push({
+          start: bindingStart + filter.argsOffset,
+          end: bindingStart + filter.argsOffset + filter.name.length,
+          message: `フィルタ "${filter.name}" の第${i + 1}引数は ${expectedArgType} 型が必要です（"${filter.args[i]}" は ${actualArgType} 型）`,
+          severity: 'warning',
+        });
+      }
+    }
+  }
+
+  return diagnostics;
 }
 
 /**
@@ -376,11 +503,44 @@ function splitByPipe(value: string): string[] {
 }
 
 /**
- * パスが状態パスセットに存在するかを判定する。
- * 完全一致のみ。
+ * パスの存在検証を行い、問題があれば診断メッセージを返す（なければ null）。
+ *
+ * `$` 名前空間はランタイム（proxy/traps/get.ts・event/handler.ts）の解決規則に合わせる:
+ * - `$1`〜`$128`: ループインデックス。状態定義に依存しないためスキップ。
+ * - `$command.<name>`: $commandTokens 宣言と照合（宣言が解析できている場合のみ）。
+ * - `$streamStatus.<name>` / `$streamError.<name>`: $streams 宣言と照合（同上）。
+ * - それ以外は状態パスセットとの完全一致。
  */
-function isValidPath(path: string, pathSet: Set<string>): boolean {
-  return pathSet.has(path);
+function validatePathExistence(
+  checkPath: string,
+  displayPath: string,
+  scopedPaths: PathCandidate[],
+  scopedPathSet: Set<string>,
+  commandNames: Set<string>,
+): string | null {
+  if (/^\$\d+$/.test(checkPath)) return null;
+
+  if (checkPath.startsWith('$command.')) {
+    if (commandNames.size > 0 && !commandNames.has(checkPath)) {
+      return `コマンドトークン "${displayPath}" は $commandTokens に宣言されていません`;
+    }
+    return null;
+  }
+
+  if (checkPath.startsWith('$streamStatus.') || checkPath.startsWith('$streamError.')) {
+    const prefix = checkPath.startsWith('$streamStatus.') ? '$streamStatus.' : '$streamError.';
+    // $streams 宣言が解析できていない（候補ゼロ）場合は誤警告を避けてスキップ
+    const hasNamespace = scopedPaths.some(p => p.path.startsWith(prefix));
+    if (hasNamespace && !scopedPathSet.has(checkPath)) {
+      return `パス "${displayPath}" は $streams 宣言に存在しません`;
+    }
+    return null;
+  }
+
+  if (!scopedPathSet.has(checkPath)) {
+    return `パス "${displayPath}" は状態定義に存在しません`;
+  }
+  return null;
 }
 
 interface TypeRequirement {

--- a/packages/vscode-wcs/src/service/completionData.ts
+++ b/packages/vscode-wcs/src/service/completionData.ts
@@ -52,6 +52,15 @@ export const PROPERTY_PREFIXES: PropertyInfo[] = [
   { name: 'class.', description: 'CSS クラスの切り替え', insertColon: false },
   { name: 'style.', description: 'インラインスタイルの設定', insertColon: false },
   { name: 'attr.', description: 'HTML 属性の設定', insertColon: false },
+  { name: 'command.', description: 'command-token 起動（右辺: $command.<name>）', insertColon: false },
+  { name: 'eventToken.', description: 'event-token 配線（右辺: $eventTokens 宣言名）', insertColon: false },
+];
+
+/** 特殊バインディング（parseBindTextsForElement.ts の special-propPart） */
+export const SPECIAL_BINDINGS: PropertyInfo[] = [
+  { name: '...', description: 'スプレッド — wcBindable の properties+inputs を一括配線', insertColon: true },
+  { name: 'radio', description: 'ラジオボタングループの双方向バインディング', insertColon: true },
+  { name: 'checkbox', description: 'チェックボックスグループの双方向バインディング', insertColon: true },
 ];
 
 /**
@@ -83,8 +92,14 @@ export const COMMON_EVENTS: PropertyInfo[] = [
   { name: 'onmouseout', description: 'マウスアウトイベント', insertColon: true },
 ];
 
-/** イベント修飾子 */
+/**
+ * バインディング修飾子（`prop#modifier` — カンマ区切りで複数指定可）。
+ * prevent/stop はイベント系、ro は two-way / radio / checkbox の書き戻し抑止。
+ * このほか two-way では `on<event>`（例: `value#onblur`）でトリガーイベントを上書きできる
+ * （event/twowayHandler.ts）— イベント名は自由記述のため静的候補には含めない。
+ */
 export const EVENT_MODIFIERS = [
   { name: 'prevent', description: 'event.preventDefault() を呼び出す' },
   { name: 'stop', description: 'event.stopPropagation() を呼び出す' },
+  { name: 'ro', description: '双方向バインディングの書き戻しを抑止（読み取り専用）' },
 ];

--- a/packages/vscode-wcs/src/service/stateAnalyzer.ts
+++ b/packages/vscode-wcs/src/service/stateAnalyzer.ts
@@ -10,15 +10,25 @@
 
 /** パス候補 */
 export interface PathCandidate {
-  /** ドット区切りパス（例: "users.*.name"） */
+  /** ドット区切りパス（例: "users.*.name"、"$command.play"） */
   path: string;
-  /** パスの種別（method は検証専用、補完候補には出さない） */
-  kind: 'data' | 'computed' | 'method' | 'list';
+  /**
+   * パスの種別（method は検証専用、補完候補には出さない）。
+   * - command: `$commandTokens` 宣言から導出した `$command.<name>` パス
+   * - eventToken: `$eventTokens` 宣言から導出したトークン名（`eventToken.<prop>:` の右辺）
+   */
+  kind: 'data' | 'computed' | 'method' | 'list' | 'command' | 'eventToken';
   /** 値の型ヒント（推定） */
   typeHint?: string;
   /** 所属する state 名（デフォルト: 'default'） */
   stateName: string;
 }
+
+// ランタイム予約キー（@wcstack/state src/define.ts が正本）。
+// トップレベルの `$` プレフィックスキーは宣言・API 名前空間でありデータパスにならない。
+const RESERVED_STREAMS_KEY = '$streams';
+const RESERVED_COMMAND_TOKENS_KEY = '$commandTokens';
+const RESERVED_EVENT_TOKENS_KEY = '$eventTokens';
 
 /**
  * export default { ... } のオブジェクトリテラルからパス候補を生成する。
@@ -32,8 +42,17 @@ export function analyzeStatePaths(scriptContent: string, stateName: string = 'de
 
   const paths: PathCandidate[] = [];
   const topLevelProps = parseTopLevelProperties(objectContent);
+  // `$streams` の値プロパティ実体化はループ後に処理する（明示宣言されたプロパティが優先）
+  const pendingStreamValues: PropertyInfo[] = [];
 
   for (const prop of topLevelProps) {
+    // トップレベルの `$` プレフィックスキーは予約名（$streams/$commandTokens/$eventTokens/
+    // $on/$bindables/$connectedCallback 等）。データパスにせず宣言由来の候補だけを導出する。
+    if (prop.name.startsWith('$')) {
+      collectReservedKeyPaths(prop, paths, pendingStreamValues, stateName);
+      continue;
+    }
+
     if (prop.kind === 'method') {
       // メソッドはパス補完には含めないが、検証用に登録
       paths.push({ path: prop.name, kind: 'method', stateName });
@@ -46,56 +65,143 @@ export function analyzeStatePaths(scriptContent: string, stateName: string = 'de
       continue;
     }
 
-    // データプロパティ
-    paths.push({ path: prop.name, kind: 'data', typeHint: prop.typeHint, stateName });
+    pushDataPropertyPaths(prop, paths, stateName);
+  }
 
-    // 配列の場合、ワイルドカードパスと子パス、組み込みプロパティを生成
-    if (prop.value && isArrayLiteral(prop.value)) {
-      paths.push({ path: `${prop.name}.*`, kind: 'list', stateName });
-      paths.push({ path: `${prop.name}.length`, kind: 'data', typeHint: 'number', stateName });
-      const elementProps = extractArrayElementProperties(prop.value);
-      for (const childProp of elementProps) {
+  // $streams 宣言による値プロパティの実体化（processStreamsDeclaration §1-3 相当）。
+  // ユーザーが同名プロパティを明示宣言している場合は上書きしない。
+  for (const streamValue of pendingStreamValues) {
+    if (paths.some(p => p.stateName === stateName && p.path === streamValue.name)) continue;
+    pushDataPropertyPaths(streamValue, paths, stateName);
+  }
+
+  return paths;
+}
+
+/**
+ * トップレベルの `$` 予約キーから、バインディングで使える派生パス候補を導出する。
+ *
+ * - `$streams: { <name>: { initial?, ... } }` → 値プロパティ `<name>`（実体化・後処理）＋
+ *   `$streamStatus.<name>` / `$streamError.<name>`（読み取り専用名前空間パス）
+ * - `$commandTokens: ["a", ...]` → `$command.<a>`（kind: 'command'）
+ * - `$eventTokens: ["a", ...]` → `<a>`（kind: 'eventToken'）
+ * - その他（`$on` / `$bindables` / ライフサイクル等）→ 候補なし
+ */
+function collectReservedKeyPaths(
+  prop: PropertyInfo,
+  paths: PathCandidate[],
+  pendingStreamValues: PropertyInfo[],
+  stateName: string,
+): void {
+  if (prop.name === RESERVED_STREAMS_KEY && prop.kind === 'data' && prop.value && isObjectLiteral(prop.value)) {
+    const entries = parseTopLevelProperties(extractObjectContent(prop.value));
+    for (const entry of entries) {
+      // ストリーム名はフラットなプロパティ名のみ（`$` 始まりはランタイムが拒否）
+      if (entry.kind !== 'data' || entry.name.startsWith('$')) continue;
+      const initial = entry.value && isObjectLiteral(entry.value)
+        ? findStreamInitialProperty(entry.value)
+        : undefined;
+      pendingStreamValues.push({
+        name: entry.name,
+        kind: 'data',
+        value: initial?.value,
+        typeHint: initial?.typeHint,
+      });
+      paths.push({ path: `$streamStatus.${entry.name}`, kind: 'data', typeHint: 'string', stateName });
+      paths.push({ path: `$streamError.${entry.name}`, kind: 'data', stateName });
+    }
+    return;
+  }
+
+  if (prop.name === RESERVED_COMMAND_TOKENS_KEY && prop.value) {
+    for (const name of extractStringArrayItems(prop.value)) {
+      paths.push({ path: `$command.${name}`, kind: 'command', stateName });
+    }
+    return;
+  }
+
+  if (prop.name === RESERVED_EVENT_TOKENS_KEY && prop.value) {
+    for (const name of extractStringArrayItems(prop.value)) {
+      paths.push({ path: name, kind: 'eventToken', stateName });
+    }
+    return;
+  }
+}
+
+/**
+ * `$streams` エントリ定義オブジェクトから `initial` プロパティを取り出す。
+ */
+function findStreamInitialProperty(entryValue: string): PropertyInfo | undefined {
+  const defProps = parseTopLevelProperties(extractObjectContent(entryValue));
+  return defProps.find(p => p.kind === 'data' && p.name === 'initial');
+}
+
+/**
+ * 配列リテラルから文字列リテラル要素を取り出す（`$commandTokens` / `$eventTokens` 用）。
+ */
+function extractStringArrayItems(value: string): string[] {
+  if (!isArrayLiteral(value)) return [];
+  const items: string[] = [];
+  const regex = /["']([^"'\\]+)["']/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(value)) !== null) {
+    items.push(match[1]);
+  }
+  return items;
+}
+
+/**
+ * データプロパティ1つ分のパス候補を生成する
+ * （配列ならワイルドカード・`.length`・要素子パス、オブジェクトなら子パスも展開）。
+ */
+function pushDataPropertyPaths(prop: PropertyInfo, paths: PathCandidate[], stateName: string): void {
+  // データプロパティ
+  paths.push({ path: prop.name, kind: 'data', typeHint: prop.typeHint, stateName });
+
+  // 配列の場合、ワイルドカードパスと子パス、組み込みプロパティを生成
+  if (prop.value && isArrayLiteral(prop.value)) {
+    paths.push({ path: `${prop.name}.*`, kind: 'list', stateName });
+    paths.push({ path: `${prop.name}.length`, kind: 'data', typeHint: 'number', stateName });
+    const elementProps = extractArrayElementProperties(prop.value);
+    for (const childProp of elementProps) {
+      paths.push({
+        path: `${prop.name}.*.${childProp.name}`,
+        kind: 'data',
+        typeHint: childProp.typeHint,
+        stateName,
+      });
+    }
+  }
+
+  // オブジェクトの場合、子パスを生成
+  if (prop.value && isObjectLiteral(prop.value)) {
+    const childProps = parseTopLevelProperties(extractObjectContent(prop.value));
+    for (const childProp of childProps) {
+      if (childProp.kind === 'data') {
         paths.push({
-          path: `${prop.name}.*.${childProp.name}`,
+          path: `${prop.name}.${childProp.name}`,
           kind: 'data',
           typeHint: childProp.typeHint,
           stateName,
         });
-      }
-    }
 
-    // オブジェクトの場合、子パスを生成
-    if (prop.value && isObjectLiteral(prop.value)) {
-      const childProps = parseTopLevelProperties(extractObjectContent(prop.value));
-      for (const childProp of childProps) {
-        if (childProp.kind === 'data') {
-          paths.push({
-            path: `${prop.name}.${childProp.name}`,
-            kind: 'data',
-            typeHint: childProp.typeHint,
-            stateName,
-          });
-
-          // ネストした配列
-          if (childProp.value && isArrayLiteral(childProp.value)) {
-            paths.push({ path: `${prop.name}.${childProp.name}.*`, kind: 'list', stateName });
-            paths.push({ path: `${prop.name}.${childProp.name}.length`, kind: 'data', typeHint: 'number', stateName });
-            const grandchildProps = extractArrayElementProperties(childProp.value);
-            for (const gc of grandchildProps) {
-              paths.push({
-                path: `${prop.name}.${childProp.name}.*.${gc.name}`,
-                kind: 'data',
-                typeHint: gc.typeHint,
-                stateName,
-              });
-            }
+        // ネストした配列
+        if (childProp.value && isArrayLiteral(childProp.value)) {
+          paths.push({ path: `${prop.name}.${childProp.name}.*`, kind: 'list', stateName });
+          paths.push({ path: `${prop.name}.${childProp.name}.length`, kind: 'data', typeHint: 'number', stateName });
+          const grandchildProps = extractArrayElementProperties(childProp.value);
+          for (const gc of grandchildProps) {
+            paths.push({
+              path: `${prop.name}.${childProp.name}.*.${gc.name}`,
+              kind: 'data',
+              typeHint: gc.typeHint,
+              stateName,
+            });
           }
         }
       }
     }
   }
-
-  return paths;
 }
 
 /**
@@ -138,6 +244,8 @@ function collectJsonPaths(
   if (depth > 5) return; // 深すぎるネストは無視
 
   for (const [key, value] of Object.entries(obj)) {
+    // トップレベルの `$` キーは予約名（JSON state に書いてもデータパスにはならない）
+    if (prefix === '' && key.startsWith('$')) continue;
     const path = prefix ? `${prefix}.${key}` : key;
     const typeHint = inferJsonTypeHint(value);
 
@@ -208,7 +316,9 @@ function extractDefaultExportObject(script: string): string | null {
  */
 function parseTopLevelProperties(objectContent: string): PropertyInfo[] {
   const props: PropertyInfo[] = [];
-  const regex = /(?:get\s+(?:"([^"]+)"|'([^']+)'|(\w+))\s*\(\s*\))|(?:(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{)|(?:(?:"([^"]+)"|'([^']+)'|(\w+))\s*:\s*)/g;
+  // 名前は `$` プレフィックスを含めて捕捉する（`\w` だけだと `$streams:` の
+  // `streams` 部分にマッチして偽のパスが生まれる）
+  const regex = /(?:get\s+(?:"([^"]+)"|'([^']+)'|([$\w]+))\s*\(\s*\))|(?:(?:async\s+)?([$\w]+)\s*\([^)]*\)\s*\{)|(?:(?:"([^"]+)"|'([^']+)'|([$\w]+))\s*:\s*)/g;
 
   let match: RegExpExecArray | null;
   while ((match = regex.exec(objectContent)) !== null) {

--- a/packages/vscode-wcs/src/service/wcsCompletionPlugin.ts
+++ b/packages/vscode-wcs/src/service/wcsCompletionPlugin.ts
@@ -11,6 +11,7 @@ import {
   BUILTIN_FILTERS,
   COMMON_PROPERTIES,
   PROPERTY_PREFIXES,
+  SPECIAL_BINDINGS,
   STRUCTURAL_DIRECTIVES,
   COMMON_EVENTS,
   EVENT_MODIFIERS,
@@ -114,6 +115,13 @@ export function createWcsCompletionPlugin(): LanguageServicePlugin {
                     insertText: p.insertColon ? `${p.name}: ` : p.name,
                     sortText: `2_${p.name}`,
                   })),
+                  ...SPECIAL_BINDINGS.map(p => ({
+                    label: p.name,
+                    kind: 14 as const, // Keyword
+                    detail: p.description,
+                    insertText: p.insertColon ? `${p.name}: ` : p.name,
+                    sortText: `2_${p.name}`,
+                  })),
                   ...COMMON_EVENTS.map(p => ({
                     label: p.name,
                     kind: 23 as const, // Event
@@ -164,18 +172,28 @@ export function createWcsCompletionPlugin(): LanguageServicePlugin {
               const targetStateName = context.targetState || 'default';
               const isEvent = context.propName.startsWith('on');
               const isForValue = context.propName === 'for';
+              const isCommandProp = context.propName.startsWith('command.');
+              const isEventTokenProp = context.propName.startsWith('eventToken.');
 
               let pathCandidates = allPaths.filter(p => p.stateName === targetStateName);
 
-              if (isEvent) {
-                // イベントハンドラ: メソッドのみ表示
-                pathCandidates = pathCandidates.filter(p => p.kind === 'method');
+              if (isCommandProp) {
+                // command.<method>: の右辺は $command.<name> のみ
+                pathCandidates = pathCandidates.filter(p => p.kind === 'command');
+              } else if (isEventTokenProp) {
+                // eventToken.<prop>: の右辺は $eventTokens 宣言名のみ
+                pathCandidates = pathCandidates.filter(p => p.kind === 'eventToken');
+              } else if (isEvent) {
+                // イベントハンドラ: メソッドと $command.<name> を表示
+                pathCandidates = pathCandidates.filter(p => p.kind === 'method' || p.kind === 'command');
               } else if (isForValue) {
                 // for: の値: 配列型のみ表示
                 pathCandidates = pathCandidates.filter(p => p.typeHint === 'array');
               } else {
-                // データバインディング: メソッドを除外
-                pathCandidates = pathCandidates.filter(p => p.kind !== 'method');
+                // データバインディング: メソッド・トークン系を除外
+                pathCandidates = pathCandidates.filter(
+                  p => p.kind !== 'method' && p.kind !== 'command' && p.kind !== 'eventToken',
+                );
                 if (!insideFor) {
                   // for 外: パターンパス（* 含む）を除外
                   pathCandidates = pathCandidates.filter(p => !p.path.includes('*'));
@@ -228,15 +246,19 @@ export function createWcsCompletionPlugin(): LanguageServicePlugin {
 
               const items: any[] = pathCandidates.map(p => ({
                 label: p.path,
-                kind: (p.kind === 'method'   ? 2
-                    : p.kind === 'computed' ? 10
-                    : p.kind === 'list'     ? 18
-                    :                          6) as 2 | 6 | 10 | 18,
+                kind: (p.kind === 'method'     ? 2
+                    : p.kind === 'computed'   ? 10
+                    : p.kind === 'list'       ? 18
+                    : p.kind === 'command'    ? 3
+                    : p.kind === 'eventToken' ? 23
+                    :                            6) as 2 | 3 | 6 | 10 | 18 | 23,
                 detail: [
                   p.typeHint ? `(${p.typeHint})` : '',
                   p.kind === 'computed' ? 'computed' : '',
                   p.kind === 'list' ? 'list' : '',
                   p.kind === 'method' ? 'method' : '',
+                  p.kind === 'command' ? 'command token' : '',
+                  p.kind === 'eventToken' ? 'event token' : '',
                 ].filter(Boolean).join(' ') || undefined,
                 sortText: `1_${p.path}`,
               }));
@@ -430,7 +452,7 @@ function validateTemplateSyntax(
         const forPath = insideFor ? getInnermostForPath(html, item.matchStart, bindAttrName) : null;
         if (forPath && !forPath.startsWith('.')) {
           const expandedPath = `${forPath}.*.${pathPart.slice(1)}`;
-          if (!isValidTemplatePath(expandedPath, pathSet)) {
+          if (!isValidTemplatePath(expandedPath, pathSet, defaultPaths)) {
             diagnostics.push({
               start: item.exprStart,
               end: item.exprStart + pathPart.length,
@@ -440,7 +462,7 @@ function validateTemplateSyntax(
           }
         }
       } else {
-        if (!isValidTemplatePath(pathPart, pathSet)) {
+        if (!isValidTemplatePath(pathPart, pathSet, defaultPaths)) {
           diagnostics.push({
             start: item.exprStart,
             end: item.exprStart + pathPart.length,
@@ -469,7 +491,19 @@ function validateTemplateSyntax(
   return diagnostics;
 }
 
-function isValidTemplatePath(path: string, pathSet: Set<string>): boolean {
+function isValidTemplatePath(
+  path: string,
+  pathSet: Set<string>,
+  scopedPaths: { path: string }[],
+): boolean {
+  // ループインデックス（$1〜$128）は状態定義に依存しない
+  if (/^\$\d+$/.test(path)) return true;
+  // $streamStatus.<name> / $streamError.<name> は $streams 宣言が解析できている場合のみ照合
+  if (path.startsWith('$streamStatus.') || path.startsWith('$streamError.')) {
+    const prefix = path.startsWith('$streamStatus.') ? '$streamStatus.' : '$streamError.';
+    const hasNamespace = scopedPaths.some(p => p.path.startsWith(prefix));
+    return !hasNamespace || pathSet.has(path);
+  }
   return pathSet.has(path);
 }
 
@@ -523,11 +557,11 @@ function buildPathAndFilterCompletions(
     };
   }
 
-  // パス補完
+  // パス補完（テキストバインディングなのでメソッド・トークン系は除外）
   const allPaths = getStatePathsFromHtml(html, stateTagName);
   const targetStateName = targetState || 'default';
   const pathCandidates = allPaths
-    .filter(p => p.kind !== 'method')
+    .filter(p => p.kind !== 'method' && p.kind !== 'command' && p.kind !== 'eventToken')
     .filter(p => p.stateName === targetStateName);
   if (pathCandidates.length === 0) return undefined;
 


### PR DESCRIPTION
- Added tests for analyzing state paths related to $streams, $commandTokens, and $eventTokens.
- Updated the stateAnalyzer to handle new paths for command and event tokens.
- Improved validation logic in bindingValidator to ensure correct usage of command and event tokens.
- Enhanced completion data to include command and event token options.
- Updated the preamble and service files to accommodate new path types and validation rules.
- Bumped version to 1.10.0 in package.json.