### PR TITLE
docs: add README for wcstack architecture hardening proposal

### DIFF
--- a/docs/architecture-hardening/01-binding-initialization-order.md
+++ b/docs/architecture-hardening/01-binding-initialization-order.md
@@ -1,0 +1,105 @@
+# タグ定義とバインディング確立の順序
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: state、UI、I/O の各カスタム要素とバインディングランタイム
+
+## 問題
+
+HTML パーサー、モジュール取得、`customElements.define()`、要素の upgrade、
+`connectedCallback()`、バインディングスクリプトの実行順は一致しない。順序を暗黙に仮定すると、
+未 upgrade 要素への書き込み、初期値の上書き、リスナー登録前の通知などが発生する。
+タグが独立して交換できる構成では、個々のタグではなく接続境界が順序を管理する必要がある。
+
+## 現状
+
+- 未定義タグへの state → element の初回 apply は、`scheduleDeferredApply` により
+  `customElements.whenDefined()` 後に最新の state 値で再試行する仕組みが実装済みである。
+- `<wcs-defined>` は、複数タグの registration 完了を `customElements.get()` / `whenDefined()` で監視し、
+  `defined`、`pending`、`missing`、`count`、`total`、`error` として公開する。`all` / `any` の集約と timeout による
+  ロード失敗検出を含むため、アプリケーション層の registration readiness は既に明示的に gate できる。
+- I/O タグを state より先に記述する構成は、現在の推奨マークアップで回避できる。
+- ただし、すべての consumer が同じ時点で ready になることや、動的 import・遅延挿入を含む
+  任意の順序で同じ結果になることは、共通契約になっていない。
+
+## `<wcs-defined>` が解決する範囲
+
+`<wcs-defined>` は registration readiness を観測して reactive state にする一方向ノードである。
+タグを load / define したり、binding runtime の discover / attach / synchronize を停止・再開したりはしない。
+したがって、利用側が `defined` を分岐条件にした処理は gate できるが、ページ内の binding 全体に自動的な
+barrier を設けるものではない。`hidden` などで表示だけを gate しても、対象要素の DOM 接続や binding は
+延期されない。
+
+| 論点 | 担当する仕組み |
+| --- | --- |
+| 複数タグの registration 完了、timeout、ロード失敗 | `<wcs-defined>` が解決済み |
+| 未定義要素への state → element 初回 apply | state の `scheduleDeferredApply` が解決済み |
+| listener 登録前に発火した初期イベント | `<wcs-defined>` では復元できない。attach 後の初期 read が必要 |
+| DOM 接続後に初期 property を読む必要 | wc-bindable の consumer option `syncOn: "connect"` を使う |
+| 接続後も続く業務データ取得 | `whenDefined()` / `syncOn` の保証外。producer の後続 event で通知する |
+| define 前後の command 順序 | `<wcs-defined>` の保証外。command 側の順序契約が必要 |
+
+特に `whenDefined()` はクラスの registration を知らせるが、対象インスタンスの業務データ取得完了や、
+過去イベントの replay を保証しない。`syncOn: "connect"` も初期 property read を最初の DOM 接続まで遅らせるだけで、
+業務データの完了待ちではない。`connectedCallbackPromise` の存在から readiness を推測してはならない。
+
+## 推奨する対策
+
+### 1. 接続を三つのフェーズに分ける
+
+1. **discover**: 宣言を読み、参照先を解決する。副作用は起こさない。
+2. **attach**: 後続変更を取り逃さないよう、先に listener / observer を登録する。
+3. **synchronize**: upgrade と接続条件を満たした対象へ初期スナップショットを適用する。
+
+`attach → synchronize` の順序を不変条件にする。同期中に変更が入った場合は、リビジョンを比較し、
+初期値で新しい変更を巻き戻さない。
+
+### 2. registration と snapshot timing を分ける
+
+- タグ集合の registration readiness をアプリケーションから扱う場合は、既存の `<wcs-defined>` を利用する。
+- binding runtime がカスタム要素の API を利用する前は、個別に `customElements.whenDefined(localName)` を待つ。
+- producer 初期値は既定の `syncOn: "call"` で listener attach と同じ同期 frame に読む。
+- unconnected `HTMLElement` を接続後に読む必要がある binding だけ、明示的に `syncOn: "connect"` を使う。
+- `syncOn: "connect"` 中も listener は先に動作し、接続前 event を配送した後で接続時 snapshot を配送する。
+- `<wcs-defined>.connectedCallbackPromise` は監視対象の完了待ちであり、property readiness として待たない。
+- 待機中に binding が破棄された場合、後続 apply を必ず無効化する。
+
+### 3. 接続処理を冪等にする
+
+binding ごとに世代番号と所有する teardown 集合を持つ。同じ接続要求の再実行は二重 listener を
+作らず、古い世代からの callback は no-op にする。切断時は listener、observer、保留中の同期を
+まとめて破棄する。
+
+## 互換性と移行
+
+既存タグのライフサイクルや `wcBindable` 宣言は変更しない。まずランタイム内部にフェーズ、ownership、世代を
+導入し、`syncOn` は consumer 側の opt-in とする。現在の `scheduleDeferredApply` は synchronize フェーズの実装として
+位置付け、個別の例外処理を共通経路へ統合する。詳細は [8 論点を横断する修正設計](09-remediation-design.md) を正とする。
+
+## 検証条件
+
+- UI / state / I/O スクリプトの全順列で最終状態が一致する。
+- 定義前に値を複数回変更しても、upgrade 後は最新値だけが適用される。
+- 待機中に要素の削除、再挿入、binding の再確立を行っても二重購読しない。
+- 動的 import の成功、失敗、長時間保留を再現できるテストを持つ。
+- teardown 後に遅延 callback が DOM や state を更新しない。
+
+## 非目標
+
+- 全タグのロード順を一つに固定すること。
+- 各カスタム要素の内部初期化方式を統一すること。
+- アプリケーション固有の「データ取得完了」を upgrade と同義にすること。
+
+## 決定ゲート
+
+1. wcstack binding grammar で `syncOn` をどう表記するか。
+2. connection observer を Document / ShadowRoot 単位で共有する実装を採るか。
+3. `syncOn` で扱えない component 固有 readiness の実例が出るまで拡張を保留するか。
+
+## 関連文書
+
+- [接続直後の初期状態配送](02-initial-state-delivery.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)
+- [既存の初期化競合分析](../state-binding-init-races.md)
+- [`<wcs-defined>` 設計メモ](../defined-tag-design.md)
+- [`@wcstack/defined` README](../../packages/defined/README.ja.md)
+- [発火タイミング契約](../timing-and-firing-contract.md)

--- a/docs/architecture-hardening/02-initial-state-delivery.md
+++ b/docs/architecture-hardening/02-initial-state-delivery.md
@@ -1,0 +1,93 @@
+# 接続直後の初期状態配送
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: producer から consumer への初期同期と、state から要素への初回 apply
+
+## 問題
+
+「接続後に最初の change イベントが来る」と仮定すると、listener 登録より前に発火した通知を失う。
+反対に、listener 登録後の初期 read を無条件に適用すると、その間に届いた新しい値を古い
+スナップショットで上書きし得る。初期状態は一度きりのイベントではなく、購読確立と一体の
+スナップショット取得として定義する必要がある。
+
+## 二つの方向を区別する
+
+### producer → consumer（観測）
+
+最新 wc-bindable コア仕様は、listener を先に登録してから初期値を読む。property の存在判定は
+`name in target` であり、property が明示的に存在すれば値が `undefined` でも consumer へ配送する。
+これは「現在値が undefined である」という観測結果である。producer snapshot の時点は consumer option の
+`syncOn: "call" | "connect"` で決まり、既定は `call` である。
+
+### state / consumer → element（入力の apply）
+
+wcstack では、state の未ロードを表す初期 `undefined` を要素の既定値へ書かず、接続時に要素値を
+pull する既存イディオムがある。この `undefined` write-skip は入力方向のポリシーであり、上記の
+観測方向に適用してはならない。
+
+## 推奨する対策
+
+### 1. listener-first snapshot を共通化する
+
+1. teardown 可能な listener を全て登録し、event を ordered inbox へ配送する。
+2. `syncOn: "call"` では同じ同期 frame で `name in target` を確認し、property を直接読む。
+3. read 中の同期 event は event payload を最終候補にし、custom getter は初期 read へ使わない。
+4. `syncOn: "connect"` では listener を動かしたまま最初の DOM 接続まで read を延期する。
+5. 接続前 event は到着順に配送し、その後の接続時 property snapshot を最終候補として配送する。
+
+`syncOn` は初期 authority とは別軸である。`BindingSession` は producer の初期配送を internal inbox で受けた後、
+`init=state | element | auto | none` の policy に従って state / element のどちらを最終値にするか決める。
+`connectedCallbackPromise` は wc-bindable の snapshot timing 契約ではないため暗黙に待たない。
+
+listener install または初期 read が throw した場合は、その binding が既に登録した cleanup を全て best-effort で実行する。
+初期 read 途中まで配送済みの property は rollback しない。詳細な状態機械は
+[8 論点を横断する修正設計](09-remediation-design.md) を正とする。
+
+### 2. 初期値と変更通知を診断上区別する
+
+配送エンベロープまたは開発用 side channel に `phase: "snapshot" | "change"` と binding id を残す。
+通常の consumer API を変更しない場合でも、デバッグ時に初期同期か後続変更か判別できるようにする。
+
+### 3. `undefined` の意味を宣言する
+
+- 観測可能 property が存在し値が `undefined`: 有効な初期スナップショット。
+- 入力ソースが未初期化の `undefined`: apply を保留できる。
+- property 自体が存在しない: 宣言不整合として診断する。
+
+将来メタデータ化する場合は、`undefined` 一値に「未ロード」「消去」「有効値」を重ねず、明示的な
+presence / readiness を追加する。
+
+## 互換性と移行
+
+既存イベント名と property 値は変えない。まず binding ランタイムの接続アルゴリズムと診断情報を
+変更し、入力方向の `undefined` write-skip は既存互換として維持する。新しい presence 表現を導入する
+場合は opt-in 宣言とし、旧 consumer には従来値だけを渡す。
+
+## 検証条件
+
+- upstream observer conformance vectors を同じ adapter test として実行する。
+- `syncOn=call` の read 中 event は payload、`syncOn=connect` の接続前 event は接続時 snapshot が最後になる。
+- connect 前の dispose、connect → disconnect race、ShadowRoot / structural Content の接続を検証する。
+- 明示的に存在する `undefined` property が producer → consumer へ一度配送される。
+- 未ロード state の `undefined` が state → element の既定値を消さない。
+- 同一値の初期通知が重複しても、無限伝播や二重副作用を起こさない。
+- 一つの bind generation では初期 snapshot が高々一回で、再 bind 時だけ新 generation になる。
+
+## 非目標
+
+- 初期値が必ず非 `undefined` であると保証すること。
+- すべての producer に永続ログやグローバル時計を要求すること。
+- 初期スナップショットを業務上の「初回イベント」として数えること。
+
+## 決定ゲート
+
+1. binding grammar の `syncOn` / `init` modifier 表記。
+2. state slot の initialized bit をどの内部 API で公開するか。
+3. snapshot / change の区別を公開 API ではなく開発用計装に限定するか。
+
+## 参照
+
+- [wc-bindable SPEC（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC.md)
+- [タグ定義とバインディング確立の順序](01-binding-initialization-order.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)
+- [既存の初期化競合分析](../state-binding-init-races.md)

--- a/docs/architecture-hardening/03-two-way-echo-control.md
+++ b/docs/architecture-hardening/03-two-way-echo-control.md
@@ -1,0 +1,87 @@
+# 双方向バインディングのエコー制御
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: UI ↔ state、state ↔ I/O などの双方向経路
+
+## 問題
+
+A の変更を B に書き、B の change を再び A に書く単純な双方向 binding は、同期的な再入、
+同値イベント、正規化、非同期通知によってエコーループを作る。単純な boolean の「更新中」フラグは、
+非同期境界や A → B → C → A の循環を越えられず、正当なユーザー変更まで捨てることがある。
+
+## 推奨する対策
+
+### 1. 変更に provenance を持たせる
+
+各伝播へ少なくとも次を割り当てる。
+
+- `transactionId`: 一つの原因から派生した伝播系列。
+- `originId`: 最初に変更を生成した node / binding。
+- `hopId` または訪問済み binding 集合: 同じ edge への再入検出。
+- `revision`: origin 内の単調増加番号。
+
+同じ `transactionId` が同じ binding edge に戻った場合だけ抑止する。別 transaction の変更は、処理中でも
+正当な入力として扱う。公開値にメタデータを混ぜず、ランタイム内部または side channel で運ぶ。
+
+### 2. write と notification を分ける
+
+入力 property への write が必ず change を表すとは限らない。binding は「値を書いた」ことと
+「producer が変更を確定して通知した」ことを別に追跡する。正規化する要素では、write した値ではなく
+通知または read-back された確定値を state へ戻す。
+
+### 3. 同値ガードを補助線として使う
+
+`Object.is(previous, next)` を標準の短絡条件にし、構造値の比較はタグまたは binding が明示した比較器に
+限定する。同値ガードは計算量を減らすが、それだけをループ防止の正しさの根拠にはしない。
+
+### 4. 収束しない変換を診断する
+
+一 transaction の hop 数に診断上限を置く。上限到達時は、経路、各hopの値型・同一性、正規化有無を
+開発用フックへ記録して当該 transaction の未処理配送だけを停止する。既適用値はrollbackせず、
+updaterから例外を投げない。値payloadは既定では記録しない。
+
+## 推奨アルゴリズム
+
+1. 外部入力に新しい `transactionId` と origin revision を付ける。
+2. edge が同 transaction を処理済みなら配送しない。
+3. 同値なら write を省略する。ただし edge を処理済みとして記録する。
+4. setter call stack内の同期通知は、member / binding generation付きreceiptからprovenanceを継承する。
+5. 非同期通知はrevision / cause token extensionがある場合だけ継承し、untagged eventは新transactionにする。
+6. untagged eventは`Object.is`同値ならstate更新を短絡できるが、時間窓だけのledgerでuser eventを抑止しない。
+7. transaction 完了後、receipt と訪問集合を解放する。
+
+## 互換性と移行
+
+既存イベント payload は変更しない。第一段階では binding ランタイム内部の transaction context、同値ガード、
+同期scope receipt、診断だけを追加する。非同期にfresh objectを生成して通知する双方向タグは、意味的同値なら
+通知しない契約を持つか、revision / cause token / equalityの明示extensionを採用する必要がある。同じobjectの
+in-place変更もreferenceだけでは識別不能であり、core eventだけで完全解決できるとは主張しない。
+
+## 検証条件
+
+- A ↔ B の同期通知はreceiptで停止し、microtask / task通知はrevision / cause extension有無を分けて検証する。
+- untagged delayed fresh-object echoを「解決済み」と誤判定せず、明示diagnosticまたはcomponent contractで扱う。
+- A → B → C → A の循環を検出できる。
+- trim、clamp、型変換などの正規化後の値が両端で収束する。
+- 処理中に発生した別のユーザー入力を誤って破棄しない。
+- `NaN`、`-0`、オブジェクト参照、カスタム比較器のケースを固定テストにする。
+- teardown 後に receipt や transaction context が残らない。
+
+## 非目標
+
+- 任意の相互変換が数学的に収束することの自動証明。
+- オブジェクト全体の暗黙 deep equality。
+- 業務上の競合解決や共同編集アルゴリズムの代替。
+
+## 決定ゲート
+
+1. provenance を binding 内部だけに置くか、タグが継承できる opt-in API を設けるか。
+2. hop 上限を警告、例外、transaction 停止のどれにするか。
+3. 非同期echoの実例に対してrevision / cause / equality extensionのどれを採るか。
+
+## 関連文書
+
+- [接続直後の初期状態配送](02-initial-state-delivery.md)
+- [観測性・デバッグと wc-bindable 境界](05-observability-and-wc-bindable.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)
+- [発火タイミング契約](../timing-and-firing-contract.md)

--- a/docs/architecture-hardening/04-async-execution-and-wc-bindable.md
+++ b/docs/architecture-hardening/04-async-execution-and-wc-bindable.md
@@ -1,0 +1,115 @@
+# 非同期実行と wc-bindable 境界
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: fetch、worker、storage、stream、remote adapter を含む非同期 I/O ノード
+- **外部仕様スナップショット**: wc-bindable-protocol
+  `5ec0deef212578a072b2f669d2a5554f254253e0`、`@wc-bindable/core@0.8.0`
+
+## 問題
+
+古い要求が新しい要求より後に完了すると、現在の入力と無関係な結果で state を巻き戻す。
+`AbortController` は通信量を減らせても、既に完了した処理、キャンセル非対応 API、remote peer の副作用を
+取り消せない。正しさには「どの結果が現在も commit 権を持つか」という明示的な順序契約が必要である。
+
+## 現状の設計資産
+
+- `docs/async-execution-model.md` は `latest`、`queue`、`exhaust`、`overlap` の execution lane と、
+  world / operation generation を定義している。
+- `docs/async-io-node-guidelines.md` は Core / Shell 分離、never-throw 境界、`_gen` による古い結果の抑止、
+  `observe()` / `dispose()`、ready、SSR を推奨している。
+- これらは良い基礎だが、wc-bindable の property 観測、input 宣言、command 呼び出し、remote wire の
+  どの意味に対応するかを混同しないための境界整理が必要である。
+
+## wc-bindable との境界
+
+| 面 | 最新仕様で保証されること | wcstack が追加で決めること |
+| --- | --- | --- |
+| コア `properties` | producer → consumer の初期同期と後続観測 | 結果を commit できる generation、lane |
+| コア `inputs` / `commands` | 検証可能な宣言メタデータ | 実際の呼び出し方法、再入・競合ポリシー |
+| Extension 1 | `set`、`setWithAck`、`invoke` の呼び出し面 | command ごとの lane、冪等性、業務上の再試行 |
+| remote extension | channel 内順序、at-most-once、ack、timeout、AbortSignal、back-pressure | timeout 後の遅延副作用、再接続後の commit 権 |
+
+wcstack の command-token はローカルのリアクティブ機構であり、それだけで wc-bindable Extension 1 の
+`invoke` 意味論を満たすわけではない。両者を接続する adapter は、能力発見、引数・結果、エラー、timeout、
+teardown を明示的に変換する。
+
+## 推奨する実行契約
+
+### 1. owner、lane、attempt を分ける
+
+各開始要求に `operationId`、I/O Core の `ownerGeneration`、lane固有stateを割り当てる。retryの
+`attempt` / `AbortSignal` はlogical operationとは別objectにする。BindingSession generationとI/O generation、
+remote reconnectのconnection generationを共有しない。
+結果の commit 条件は次のすべてを満たすこととする。
+
+1. I/O owner lifecycle generation が一致する。
+2. operation がterminal settle前である。
+3. `latest`のepoch、`queue`のactive head、`exhaust`のactive ID、`overlap`のactive setをpolicy別に満たす。
+4. remote 応答の場合、対応するconnection / request identityが一致する。
+
+`latest` は同じ key の最新 generation だけ、`queue` は開始順、`exhaust` は実行中の追加要求を拒否または
+集約する。`overlap` は各実行を置換せず、各完了が到着順に同じ観測面へ上書きする（後着勝ち）。
+`operationId` と active set は terminal CAS、teardown、in-flight count、開発用 trace の内部 bookkeeping に限り、
+operation ごとの結果を公開 observable として個別追跡しない。個別結果を公開する `parallel` は本設計の対象外である。
+lane はタグの暗黙実装ではなく、宣言または binding 設定から選べるようにする。
+
+### 2. cancel と commit guard を併用する
+
+新しい要求または teardown 時に `AbortSignal` を伝播し、可能なら処理を停止する。ただしキャンセル成否に
+かかわらず、完了時にowner generationとpolicy eligibilityを再検査する。成功・error・timeoutは
+`pending → committing → terminal` のCASを高々一回claimし、古い成功・失敗・進捗をstateへcommitしない。
+timeout errorはticketを先に失効させず、eligibleなtimeout outcomeがcommitした後にresourceをabort / releaseする。
+
+### 3. 結果を状態機械として公開する
+
+最低限 `idle | pending | success | error | cancelled | stale` を内部で区別する。通常の property 面には
+現在の結果を公開し、operation identity、試行回数、開始・終了理由は開発用 side channel に送る。
+エラーは Promise の未処理 rejection にせず、宣言された error property / event または ack 結果へ正規化する。
+
+### 4. remote 固有の制約を保持する
+
+- `set` は fire-and-forget なので、受理確認が必要な操作には使用しない。
+- `setWithAck` のresolveはassignment適用のackであり、副作用完了や状態安定ではない。reject時は適用済みか不明である。
+- `setWithAck` / `invoke` の timeout / AbortSignal はclient待機だけを解放し、peer側処理をcancelしない。再試行には
+  idempotency key または業務上の重複許容が必要である。
+- at-most-once は exactly-once ではなく、切断時には結果不明になり得る。
+- ordinary wire payload は JSON 表現可能な値に制限し、関数、DOM node、任意の class instance を送らない。
+  observable の top-level `undefined` は仕様の out-of-band 表現に従う。
+- 宣言された capability、pending 上限、back-pressure 方針を接続前に検査する。
+
+## 互換性と移行
+
+既存 I/O タグには現在の挙動を表す既定 lane を割り当て、最初は内部 generation guard と診断だけを追加する。
+lane や idempotency の宣言は追加 metadata とし、未認識 consumer は無視できるようにする。remote adapter は
+wc-bindable の capability negotiation を使い、Extension 1 非対応 peer へ command を暗黙に模倣しない。
+
+## 検証条件
+
+- A、B の順に開始し B、A の順に完了するケースを全 lane で検証する。
+- success だけでなく error、progress、retry timer も古い generation から commit されない。
+- abort 非対応 Promise が teardown 後に完了しても状態を変更しない。
+- remote の timeout、遅延 ack、切断、再接続、pending 上限到達を再現する。
+- `set` と `setWithAck` の保証をテスト名と API 文書で明確に分ける。
+- JSON 非互換 payload と capability 不足を接続時または送信前に診断する。
+
+## 非目標
+
+- すべての外部副作用を取り消すこと。
+- at-most-once transport から exactly-once 業務処理を自動生成すること。
+- コアの property 観測を command RPC として扱うこと。
+
+## 決定ゲート
+
+1. lane を I/O タグ宣言、binding 属性、両者のどこで選択するか。
+2. operation identity / idempotency key を公開 API にする範囲。
+3. stale 結果を完全に破棄するか、診断履歴だけに残すか。
+4. Extension 1 adapter の対応範囲と capability 不足時の失敗方法。
+
+## 参照
+
+- [wc-bindable SPEC（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC.md)
+- [wc-bindable Extensions（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC-extensions.md)
+- [wc-bindable remote README（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/packages/remote/README.md)
+- [非同期実行モデル](../async-execution-model.md)
+- [非同期 I/O ノード指針](../async-io-node-guidelines.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)

--- a/docs/architecture-hardening/05-observability-and-wc-bindable.md
+++ b/docs/architecture-hardening/05-observability-and-wc-bindable.md
@@ -1,0 +1,125 @@
+# 観測性・デバッグと wc-bindable 境界
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: 複数タグ、binding、非同期 operation、remote peer にまたがる因果追跡
+- **外部仕様スナップショット**: wc-bindable-protocol
+  `5ec0deef212578a072b2f669d2a5554f254253e0`、`@wc-bindable/core@0.8.0`
+
+## 問題
+
+疎結合なタグでは、一つのユーザー操作が state、filter、I/O、remote adapter を横断する。
+個々の property をログするだけでは「誰が、どの binding を経て、なぜこの値を確定したか」が分からない。
+一方、デバッグ情報を通常 payload や wc-bindable の観測規則へ混ぜると、タグの交換可能性と互換性を壊す。
+
+## 現状
+
+`docs/devtools-hook-protocol.md` は `globalThis.__WCSTACK_DEVTOOLS_HOOK__` を使う v1 side channel を定義し、
+timeline、binding、token emission、subscriber count を観測する。state 向け実装と DevTools overlay は
+`@wcstack/state@1.20.0` / `@wcstack/devtools@1.20.0` として 2026-07-14 時点で公開済みである。
+I/O、非同期 operation、remote peer を含む end-to-end 因果追跡は今後の範囲である。
+
+## 原則
+
+### 1. 計装をデータ面から分離する
+
+wc-bindable の `properties`、初期同期、change event、teardown の意味は変更しない。計装は optional な
+side channel とし、hook が存在しない場合の分岐コストとメモリ保持を最小化する。デバッグ consumer が
+通常 binding の購読者数、初期値、順序へ影響してはならない。
+
+### 2. 宣言と実行を別に観測する
+
+- **宣言面**: protocol / version、properties、inputs、commands、extension capability、remote declaration fingerprint。
+- **実行面**: binding attach / sync / detach、read / write / notify、command、operation、retry、commit / stale / error。
+
+宣言面は wc-bindable の discovery 結果を読み取り専用で利用する。remote の fingerprint と capability は peer が
+何を提供すると合意したかの識別に使い、実行 trace の代用にはしない。
+
+### 3. 因果 context を最小単位にする
+
+各 trace record は可能な範囲で次を持つ。
+
+- DevTools source ID、source-local sequence、任意の `traceId` / `parentId`
+- `nodeId`、`bindingId`、`operationId`、`generation`
+- `phase`（snapshot / change / command / progress / commit / stale / teardown）
+- 単調時計の timestamp と同一 node 内 sequence
+- outcome、duration、値の型。payload / preview は opt-in
+- local / remote、protocol version、capability / declaration fingerprint
+
+data-plane の `transactionId` / `visitedEdges` はtrace IDと分離する。hookがない場合も因果制御は同じで、
+hook接続時だけtraceへ投影する。通常eventがcontextを運べない場合も、binding runtimeは同期write receiptと
+operation identityから可能な範囲で関連付け、推測した関係には `inferred: true` を付ける。
+
+## 推奨する表示モデル
+
+### Graph
+
+タグと remote peer を node、property / input / command binding を edge として表示する。未定義参照、宣言にない
+path、Extension 1 非対応 command、購読者のない producer、teardown 漏れを静的・動的診断として重ねる。
+
+### Timeline
+
+一つの trace を attach → snapshot → change → operation start → remote request → commit の順に並べる。
+非同期追い越しは generation ごとの lane、古い結果は `stale`、エコー抑止は抑止した edge と理由を表示する。
+
+### Snapshot
+
+late attach した DevTools は `kind: state` / `kind: io` などsourceごとのsnapshot callbackから、
+現在の graph、binding、購読数、進行中 operation の基準点を取得し、
+以後の event を追記する。attach 前の完全履歴を復元できるとは主張しない。
+
+## 安全性とコスト
+
+- 値payloadとpreviewは既定で保存せず、型など値を保持しないmetadataだけを出す。previewは明示policyでopt-inにする。
+- credential、header、storage 値、File / Blob の内容は既定で表示しない。
+- data hot pathはbounded ring bufferへのappendだけを行い、subscriberはmicrotask / animation frameでdrainする。
+- overflowはtraceだけをdropしてdrop数を記録する。無制限queueを作らない。
+- remote trace context は明示的な capability がある場合だけ送る。相手に内部 DOM path や秘密値を漏らさない。
+- hook callbackとopt-in serializerの例外、遅延、再入はbridgeで隔離し、通常処理へ伝播させない。
+- serializerはdrain側で実行し、depth、byte数、時間を制限する。getter関数やlive handleを直列化しない。
+
+## wc-bindable との整合
+
+- コア宣言の `inputs` / `commands` はメタデータであり、trace 上の command 実行を証明しない。
+- Extension 1 対応 surface の `set`、`setWithAck`、`invoke` は別種の span として記録する。
+- remote channel の順序、request id、ack、timeout、AbortSignal、back-pressure を保持し、観測上の timestamp だけで
+  分散した全順序を捏造しない。
+- 未知の optional field / extension は表示できなくても binding 自体を拒否しない。
+- デバッグ拡張がコアの `protocol` 識別子や値配送を変更してはならない。
+
+## 互換性と移行
+
+既存 v1 hook を維持し、record kind と optional field を追加する。I/O と binding runtime を段階的に instrument し、
+未対応タグは graph 上で「opaque」と表示する。破壊的な hook schema 変更が必要な場合だけ hook version を上げ、
+通常の wc-bindable version とは独立に交渉する。
+
+## 検証条件
+
+- hook の有無でアプリケーションの最終状態と通知順が変わらない。
+- 初期 snapshot、後続 change、エコー抑止、stale commit 拒否を timeline で区別できる。
+- A → state → I/O → remote → state → UI の因果系列を一つの trace として辿れる。
+- late attach 時に基準 snapshot と「履歴欠落」を正しく表示する。
+- ring buffer overflow、hook 例外、DevTools detach 後も通常処理が継続する。
+- redact policy と remote capability 不足時に秘密値や trace context を送らない。
+
+## 非目標
+
+- 分散システム全体の厳密な全順序を提供すること。
+- 過去の全 payload を本番環境で永続保存すること。
+- DevTools のためにコア binding protocol の意味を変更すること。
+
+## 決定ゲート
+
+1. trace context をタグへ渡す opt-in API の範囲。
+2. node / binding identity の安定性と DOM 再接続時の扱い。
+3. preview / redact の既定値とユーザー設定面。
+4. remote trace capability を wcstack adapter metadata と wc-bindable extension のどちらで宣言するか。
+
+## 参照
+
+- [wc-bindable SPEC（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC.md)
+- [wc-bindable Extensions（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC-extensions.md)
+- [wc-bindable remote README（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/packages/remote/README.md)
+- [DevTools hook protocol](../devtools-hook-protocol.md)
+- [DevTools tag design](../devtools-tag-design.md)
+- [非同期実行と wc-bindable 境界](04-async-execution-and-wc-bindable.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)

--- a/docs/architecture-hardening/06-path-type-safety.md
+++ b/docs/architecture-hardening/06-path-type-safety.md
@@ -1,0 +1,98 @@
+# パス文字列の型安全性
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: `data-wcs`、state path、filter、command / event token、リストの wildcard path
+
+## 問題
+
+HTML 属性に書くパス文字列は、TypeScript の property rename や型変更から切り離される。存在しない path、
+入力と出力の型不一致、filter 後の型不一致は実行時まで残り得る。一方、文字列 DSL は buildless な利用、
+DevTools での可視性、タグ間の疎結合を支えており、すべてを TS 式へ置き換えるのは設計思想に合わない。
+
+## 現状の資産と限界
+
+- state は宣言されていない path を初期化時に拒否する。
+- `define-state` は `WcsPaths<T>` と `WcsPathValue<T, P>` を提供し、TS 内の dot path を補助する。
+- `packages/vscode-wcs` の analyzer / binding validator は path、command、filter と type hint を解析し、
+  補完と診断を提供する。
+- runtime 検証は最後の防壁になるが、HTML の編集時や CI で全参照を保証する単一の契約はまだない。
+- 動的 index、wildcard、getter / setter、filter chain では、静的に得られる型精度に限界がある。
+
+## 推奨する三層モデル
+
+### 1. authoring 型: TypeScript の path union
+
+TS から path を渡す API は `WcsPaths<T>` / `WcsPathValue<T, P>` を利用し、literal を保持する helper を用意する。
+rename 時にコンパイラが参照箇所を示せるよう、`string` へ早期に widen しない。動的 path は明示的な
+`DynamicPath` または escape hatch とし、型安全な path と見分けられるようにする。
+
+### 2. template 型: language service と CI validator
+
+VS Code の解析器を再利用できる headless validator を提供し、HTML、template literal、example を CI で検査する。
+診断には state 名、path segment、現在型、期待型、filter ごとの変換を含める。IDE と CI が別実装にならないよう、
+parser、resolver、type lattice、診断 code を共通 package に置く。
+
+### 3. runtime 型: 構造と capability の検証
+
+runtime は外部入力や動的 DOM のために残す。少なくとも undeclared path、危険な prototype key、書き込み不能
+getter、未知の command / filter、list context 外の wildcard を接続時に拒否する。値の完全な deep schema 検査は
+既定で行わず、必要な境界だけ opt-in schema / predicate を使う。
+
+## 型情報の供給
+
+state 宣言から次の中間表現を生成する。
+
+- state / path 名と readable / writable / command / event の種別
+- scalar、array、object、nullable、unknown の type hint
+- wildcard と list item の対応
+- getter / setter の有無、filter の入力・出力型
+
+custom element 側の property / input 型は、TypeScript declaration または任意の sidecar manifest から取り込む。
+wc-bindable コア宣言へ必須の型字段を追加せず、型情報がないタグは `unknown` として段階的に検査する。
+型 sidecar の versioning は [プロトコル進化と互換性](08-protocol-evolution.md) と独立に管理する。
+
+統合設計では、再利用可能な tag / filter の契約を package manifest、実アプリの state path と binding graph を
+application artifact に分ける。型語彙は JSON Schema の固定 subset とし、TypeScript 固有表現を公開 artifact の
+必須形式にはしない。探索順、同名衝突、override 規則を schema で決め、暗黙の last-file-wins merge は行わない。
+
+## filter chain の扱い
+
+各 filter は入力型、出力型、option schema を公開できるようにする。validator は左から型を畳み込み、途中の
+不一致を filter 名と位置付きで報告する。ユーザー定義 filter に情報がない場合は以後を `unknown` に落とし、
+誤った確定診断をしない。`not` のような意味変換と path 構文を混ぜない。
+
+## 互換性と移行
+
+文字列 DSL と buildless runtime は維持する。第一段階は既存 VS Code validator の共通化と CI コマンド追加で、
+警告として導入する。repository 内 example が clean になった後に、undeclared path と明白な型不一致を CI error に
+昇格する。sidecar 型情報は optional とし、旧タグ・旧 manifest は `unknown` で受け入れる。
+
+## 検証条件
+
+- state property の rename により TS、HTML、template literal の参照が CI で検出される。
+- readonly getter への双方向 write、command を通常値として読む誤りを検出する。
+- array wildcard、nested list、`.length`、nullable、union を固定 fixture で検証する。
+- filter chain の各段階と option 不一致に安定した診断 code が付く。
+- `__proto__`、`constructor`、継承名を runtime / CI の双方で拒否する。
+- 型情報なしのサードパーティタグを誤って拒否しない。
+- IDE と headless validator が同じ入力へ同じ診断を返す。
+
+## 非目標
+
+- HTML 文字列を TypeScript コンパイラだけで完全に型検査すること。
+- 任意の JavaScript getter やユーザー filter の戻り値を静的に証明すること。
+- build step を wcstack 利用の必須条件にすること。
+
+## 決定ゲート
+
+1. 共通 analyzer をどの package に切り出すか。
+2. element 型 sidecar の形式と生成元を何にするか。
+3. warning から error へ昇格する診断 code と時期。
+4. 動的 path escape hatch の構文と監査方法。
+
+## 関連文書
+
+- [define-state](../../packages/state/docs/define-state.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)
+- [プロトコル進化と互換性](08-protocol-evolution.md)
+- [観測性・デバッグと wc-bindable 境界](05-observability-and-wc-bindable.md)

--- a/docs/architecture-hardening/07-browser-capability-variance.md
+++ b/docs/architecture-hardening/07-browser-capability-variance.md
@@ -1,0 +1,105 @@
+# ブラウザ capability 差の吸収
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: permission、sensor、media、storage、screen / window、worker などブラウザ API を使う I/O タグ
+
+## 問題
+
+ブラウザ API は、constructor の有無だけでなく secure context、permission policy、ユーザー許可、OS・端末、
+実装された method、実行時の状態によって利用可否が変わる。同じブラウザ名でも capability は固定ではない。
+タグごとに判定と error 表現が異なると、交換可能な I/O ノードという利点が consumer 側の分岐へ流出する。
+
+## 推奨する共通契約
+
+### 1. feature detection を境界で行う
+
+UA 名や version ではなく、利用する constructor、method、event、secure context、permission を実行直前に検査する。
+モジュール import 時に `window`、`navigator`、DOM constructor を必須参照せず、SSR / worker では安全に
+unsupported を返す。API object は Core へ注入可能にし、Shell だけがブラウザ globals を解決する。
+
+### 2. capability と現在状態を分ける
+
+最低限、次を区別する。
+
+- `supported`: 実装と最低実行条件を満たすか。
+- `permission`: `prompt | granted | denied | unavailable`。
+- `ready`: 初期 snapshot を取得済みか。
+- `active`: 現在監視・取得しているか。
+- `error`: 直近の失敗を正規化した値。
+
+`supported: false`、ユーザーによる `denied`、一時的な `NotReadableError`、まだ未初期化を一つの falsy 値へ
+潰さない。単発 action の成功と継続 monitor の状態も分ける。
+
+### 3. never-throw 境界と安定した error taxonomy
+
+同期 throw、Promise rejection、DOMException を Shell で捕捉し、安定した `code`、`name`、`recoverable`、
+`cause`（開発時のみ）へ変換する。programmer error まで無言で握りつぶさず、公開 operation は宣言した error 面へ
+失敗を流し、開発用 hook に診断を残す。
+
+### 4. lifecycle と動的変化を扱う
+
+permission change、device 消失、page visibility、BFCache 復帰、OS による lock 解除などで capability / active 状態が
+変わり得る。observer は `observe() → dispose()` の所有権を明確にし、再接続時には新しい generation で snapshot を
+取り直す。古い callback は commit しない。
+
+### 5. adapter が差を正規化する
+
+標準 API の一部だけがない場合は、明示的な adapter で代替経路を選ぶ。semantics が異なる fallback を自動で
+同一視せず、`implementation` / `limitations` を capability metadata と診断に残す。polyfill のロードをタグが
+暗黙に行わない。
+
+## capability manifest の提案
+
+I/O タグは任意で、安定した feature id、検査結果、制約を読み取り専用 property または開発用 sidecar として
+公開できる。値は additive に拡張し、consumer は未知 field を無視する。ブラウザ名の allowlist ではなく、
+実際に確認した能力だけを表す。
+
+feature id は `web.fetch` または reverse-DNS 形式など registry で管理できる安定名とし、browser API の
+platform capability と remote connection の capability bit を別 namespace・別判定にする。sidecar は静的要件、
+runtime assessment は availability、permission、readiness、activity、precondition、epoch、直近 error を表す。
+初期化時だけでなく operation 開始直前にも必要条件を再検査する。
+
+共通 error は serializable な `WcsIoErrorInfo` と、runtime 内だけの non-cloneable な `cause` に分ける。移行時は
+既存 error property / event の shape を変更せず、まず DevTools と opt-in `errorInfo` へ共通 taxonomy を投影する。
+
+## テスト戦略
+
+- Core test: browser object を使わず、状態機械、世代、error 正規化を決定的に検証する。
+- Shell contract test: constructor / method 不在、throw、rejection、permission 遷移、dispose を fake で網羅する。
+- Browser E2E: 対応ブラウザで実 API の最小 smoke test を行う。実機依存ケースは capability 条件付きにする。
+- Conformance: 全 I/O ノードへ共通の unsupported、never-throw、ready、teardown、late callback テストを適用する。
+
+## 互換性と移行
+
+既存の `supported` property と各タグ固有 error は維持し、共通 taxonomy への mapping を追加する。
+新しい capability field は optional とし、旧 consumer が知らなくても動作する。既存の boolean が複数状態を
+潰している場合は意味を変更せず、より精密な property を追加して段階的に移行する。
+
+## 検証条件
+
+- SSR で全対象 package を import でき、browser global 不在で module evaluation が失敗しない。
+- API 全欠如と method 一部欠如を区別し、どちらも未処理例外を出さない。
+- denied、dismissed、policy blocked、insecure context、device busy を安定 code に正規化する。
+- permission / visibility / device 状態の変更後に snapshot と active が追従する。
+- disconnect 後の native event / Promise 完了が state を更新しない。
+- conformance suite が各 I/O package の同じ契約を検査する。
+
+## 非目標
+
+- すべてのブラウザに同じ物理機能を提供すること。
+- UA sniffing による将来の対応状況予測。
+- semantics の異なる fallback を完全互換として隠すこと。
+
+## 決定ゲート
+
+1. 共通 error code と capability schema の所有 package。
+2. `supported` の最低条件を constructor 存在、実行可能性のどちらで定義するか。
+3. browser E2E の必須 matrix と、実機依存テストの扱い。
+4. capability 情報を通常 property と開発用 sidecar のどちらで公開するか。
+
+## 関連文書
+
+- [非同期 I/O ノード指針](../async-io-node-guidelines.md)
+- [非同期実行と wc-bindable 境界](04-async-execution-and-wc-bindable.md)
+- [8 論点を横断する修正設計](09-remediation-design.md)
+- [発火タイミング契約](../timing-and-firing-contract.md)

--- a/docs/architecture-hardening/08-protocol-evolution.md
+++ b/docs/architecture-hardening/08-protocol-evolution.md
@@ -1,0 +1,122 @@
+# プロトコル進化と互換性
+
+- **状態**: 設計提案（未採択・未実装）
+- **対象**: wcstack の `static wcBindable`、binding core、tooling、local / remote adapter
+- **外部仕様スナップショット**: wc-bindable-protocol
+  `5ec0deef212578a072b2f669d2a5554f254253e0`、`@wc-bindable/core@0.8.0`
+
+## 問題
+
+共通プロトコルを広げるほど、古い core、新しいタグ、tooling、remote peer の組合せが増える。
+version を「完全に知っている値だけ許可する」switch にすると、optional field の追加さえ相互運用を壊す。
+反対に、破壊的変更を同じ識別子のまま version だけ上げて受け入れると、接続は成功しても意味が食い違う。
+
+## 最新 wc-bindable の互換性規則
+
+固定した最新仕様では、宣言の `version` は 1 以上の整数であり、adapter はすべての `version >= 1` を受け入れる。
+未知の optional field は無視する。additive な進化では version を上げられるが、binding contract を壊す変更は
+未知 version を拒否するのではなく、新しい `protocol` 識別子を必要とする。
+
+したがって version は feature gate ではない。local discovery は公式 helper または固定 conformance vectors に
+一致する mirror を validation gate とし、機能利用可否は field の存在、behavioral extension discovery、remote
+capability negotiation で判定する。
+
+## wcstack の現在地
+
+`protocol/wc-bindable.ts` は `version: 1` の literal 型を単一ソースとして各 package へ同期している。
+これは現在の宣言を正確に表す一方、上流仕様が許す将来の `version >= 1` を型の段階で表現できない。
+また、コメント上の command 呼び出しと「descriptive metadata」という位置付けを、コアと Extension 1 の境界に
+合わせて明文化する余地がある。本書は差分を記録するだけで、型や runtime はまだ変更しない。
+
+## 推奨する進化規則
+
+### 1. additive change を基本にする
+
+- optional field、property / input / command 宣言、extension capability の追加を許す。
+- consumer は未知 field を無視し、理解する field だけで安全に接続できるか判断する。
+- 新しい field がなくても従来意味で動作する既定値を仕様に書く。
+- field の存在が必須な機能は capability として検査し、黙って代替しない。
+
+### 2. 名前ではなく意味の破壊を判定する
+
+削除、rename、event 変更、read / write 方向変更、順序・teardown 保証の弱化は破壊的変更として扱う。
+property の値型変更も wire protocol が同じでもアプリケーション契約上は破壊的になり得る。
+移行期間は旧名 alias、旧 event の併発、adapter を用意し、警告と撤去時期を記録する。
+
+### 3. 本当に異なる契約は新 protocol にする
+
+旧 consumer が同じ宣言を安全に解釈できない場合、同じ `protocol: "wc-bindable"` の高い version で隠さず、
+新しい protocol identifier または明示的な extension を使う。一つのタグが移行期間中に両 surface を提供する
+場合は discovery の優先順位と teardown 所有権を決める。
+
+### 4. local と remote の交渉を分ける
+
+local discovery は宣言 shape と field / extension の存在で判断する。remote はさらに wire capability、
+declaration fingerprint、payload 制約、pending / ordering 能力を handshake で確認する。fingerprint の差は
+即座の非互換を意味せず、期待宣言との不一致を診断・再発見するために使う。
+
+さらに wcstack の tooling metadata は manifest extension、wc-bindable の command / mutation behavior は
+behavioral extension、wire 上の可否は remote capability、ブラウザ API の可否は platform capability と呼び分ける。
+manifest に requirement を書いても target 自身が behavioral extension 対応になるわけではない。
+
+### 5. 型定義を forward-compatible にする
+
+共有型は `version: number` と runtime validator（整数かつ 1 以上）へ寄せ、既知 field は厳密に型付けする。
+追加 metadata 用の index signature を安易に広げず、未知 field の保持・無視は parser 境界で扱う。
+`scripts/sync-protocol-types.mjs` を通して生成コピーを更新し、手編集による drift を禁止する。
+
+## 変更分類
+
+| 変更 | 原則 | 必要な対応 |
+| --- | --- | --- |
+| optional metadata 追加 | 後方互換 | 未知 field 無視、既定意味を記載 |
+| optional extension / capability 追加 | 後方互換 | discovery と graceful failure |
+| property / command の追加 | 通常は後方互換 | 名前衝突検査、tooling 更新 |
+| 名前の変更・削除 | 破壊的 | alias / adapter / deprecation |
+| event・初期同期・teardown 意味変更 | protocol contract の破壊 | 新 protocol または明示 extension |
+| remote payload / ordering 保証変更 | wire contract の破壊 | capability 交渉、必要なら新 wire protocol |
+
+## リリースと適合性
+
+1. 仕様、型、runtime validator、tooling、examples、conformance fixture を同じ変更で更新する。
+2. old core × new tag、new core × old tag、local × remote の組合せテストを追加する。
+3. 最新仕様の conformance suite と wcstack 固有拡張の suite を分離する。
+4. release note に additive / deprecated / breaking と最小 capability を記録する。
+5. deprecation は DevTools / validator で観測可能にし、削除前に利用箇所を発見できるようにする。
+
+## 互換性と移行
+
+第一段階では runtime の「version 1 固定」判定がないか監査し、`>= 1` 受理と未知 optional field 無視の
+適合テストを先に追加する。次に共有型を緩和して生成コピーを同期する。command 呼び出し機能が必要な箇所は
+コア metadata と Extension 1 adapter を区別し、既存 command-token との変換を別契約として文書化する。
+
+## 検証条件
+
+- version 1、2、大きな整数と未知 optional field を持つ宣言を既知 field の範囲で受理する。
+- 0、負数、非整数、非数、別 protocol を明確な診断で拒否する。
+- 旧 core × optional field 追加タグが従来 property を観測できる。
+- Extension 1 非対応 surface への `invoke` を capability error とし、method 名から推測して呼ばない。
+- remote declaration fingerprint 変更時に再発見し、保留中 request の所有権を混ぜない。
+- 生成型が単一ソースと一致し、package 間 drift を CI で検出する。
+
+## 非目標
+
+- 任意の破壊的変更を version number だけで自動変換すること。
+- package の SemVer と protocol / extension version を同一視すること。
+- 未知 capability の動作を推測して有効化すること。
+
+## 決定ゲート
+
+1. local runtime と tooling の version validator を共有する場所。
+2. wcstack 固有 extension の namespace、discovery、versioning 規則。
+3. command-token と Extension 1 adapter の正式な対応関係。
+4. deprecation 期間と protocol identifier 変更の承認手順。
+
+## 参照
+
+- [wc-bindable SPEC（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC.md)
+- [wc-bindable Extensions（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC-extensions.md)
+- [wc-bindable CONFORMANCE（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/CONFORMANCE.md)
+- [wc-bindable RELEASE_NOTES（固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/RELEASE_NOTES.md)
+- [wcstack の protocol 型](../../protocol/wc-bindable.ts)
+- [8 論点を横断する修正設計](09-remediation-design.md)

--- a/docs/architecture-hardening/09-remediation-design.md
+++ b/docs/architecture-hardening/09-remediation-design.md
@@ -1,0 +1,788 @@
+# 8 論点を横断する修正設計
+
+- **作成日**: 2026-07-14
+- **状態**: 統合設計提案（未採択・未実装）
+- **対象**: `@wcstack/state`、I/O Core / Shell、DevTools、VS Code 拡張、wc-bindable adapter
+- **前提**: [論点 1〜8](README.md#論点一覧) と既存の実装済み対策を置き換えず、段階的に統合する
+
+## 1. 結論
+
+修正の中心は、新しい巨大な公開プロトコルではなく、次の五つの小さな責務を導入することである。
+
+| 責務 | 役割 | 主に解決する論点 |
+| --- | --- | --- |
+| `BindableDeclarationReader` | wc-bindable 宣言を一か所で検証・解釈する | 1、6、8 |
+| `BindingSession` | definition、attach、初期同期、teardown を binding 単位で所有する | 1、2、3 |
+| `PropagationContext` | 双方向伝播の原因、通過 edge、write receipt を追跡する | 3、5 |
+| `OperationTicket` | 非同期操作の lane、世代、commit 権を管理する | 4、5 |
+| sidecar manifest / application schema | 型、非同期 policy、platform capability を tooling 向けに公開する | 4、6、7、8 |
+
+これらの実行状況を既存の DevTools hook へ side channel として送る。通常の property 値、event detail、
+command 引数、wc-bindable コアの初期同期意味論は変更しない。
+
+設計を三つの面に分ける。
+
+| 面 | 構成 | 不変条件 |
+| --- | --- | --- |
+| データ面 | `BindingSession`、`PropagationContext`、`OperationTicket` | 値と副作用の正しさを hook や timeout に依存させない |
+| 契約面 | wc-bindable 宣言 reader、sidecar、capability probe | 未知の optional 情報を無視し、必要能力だけを明示的に検査する |
+| 観測面 | DevTools hook、validator diagnostics | データ面の順序、購読数、payload を変えない |
+
+## 2. 最初に直す境界: `BindableDeclarationReader`
+
+現在の state runtime は、two-way、event-token、spread、command、attribute mirror の各経路で
+`protocol === 'wc-bindable' && version === 1` を個別に判定している。これを単一 reader へ集約する。
+ただし、reader が wc-bindable の discovery 規則を独自に作り直してはならない。
+
+```ts
+interface ReadBindableResult {
+  readonly target: WcBindableElement;
+  readonly liveDeclaration: WcBindableDeclaration;
+  knownProperties: ReadonlyMap<string, IWcBindableProperty>;
+  declaredInputs: ReadonlyMap<string, IWcBindableInput>;
+  declaredCommands: ReadonlyMap<string, IWcBindableCommand>;
+}
+
+function readBindableDeclaration(target: unknown): ReadBindableResult | null;
+```
+
+runtime reader は repository 内の canonical source から各公開 package へ生成または bundle した conformance mirror を
+validation gate として使う。mirror は固定した upstream conformance vector に一致させ、独自仕様として分岐させない。
+公式 `getWcBindableDeclaration(target)` は開発時と conformance test の参照実装（oracle）として使い、公開 artifact に
+外部 runtime import を残さない。現行の `protocol/wc-bindable.ts` は型の canonical source だけなので、runtime reader の
+canonical 実装と生成・同期検査を追加する。
+
+これにより次を保証する。
+
+1. discovery path は `target.constructor.wcBindable` の一つだけで、instance override や registry fallback を足さない。
+2. consumer-side target に `addEventListener` / `removeEventListener` があることを検査し、`dispatchEvent` は要求しない。
+3. `version` は 1 以上の整数をすべて受理し、未知の optional field を無視する。
+4. `properties` だけでなく `inputs` / `commands` を含む宣言全体の schema と名前重複を検査する。
+5. discovery 中の property access が throw しても外へ投げず、invalid declaration とする。
+6. 戻り値は live declaration であり、clone、freeze、正規化 snapshot とは扱わない。
+
+`inputs` / `commands` は宣言 interface metadata であり、存在だけから Extension 1 の `set` / `setWithAck` / `invoke`
+意味論を推測しない。local Shell への通常 assignment と、明示的に Extension-1-capable な remote / automation surface は
+別の invocation resolver で分岐する。
+
+構造化 diagnostic は validation gate の結果を上書きしない開発時 analyzer とする。静的に確定できるのは descriptor の
+shape、名前、event 文字列、getter の型までであり、「event が実際に発火する」「getter が正しい値を返す」は
+conformance test の責務である。analyzer は再度 executable metadata へアクセスし得るため、明示的な開発モードだけで動かす。
+
+共有型の `version: 1` は `version: number` へ緩和し、runtime reader が整数・下限を検査する。
+破壊的な binding contract は高い version を拒否して扱うのではなく、別 protocol identifier または
+明示 extension とする。
+
+`wcBindable` は inert JSON ではなく、getter 関数と discovery 時の property access を含む trusted executable metadata である。
+validation は sandbox ではなく、読み込んだ component code と同じ trust boundary に置く。
+
+## 3. `BindingSession`: binding に所有者を与える
+
+### 3.1 現状から変える点
+
+現在は、two-way listener、event-token、spread、初期 apply がそれぞれ別に `whenDefined()` を登録する。
+この方式では、同じ binding の phase と teardown 所有者が一つに定まらない。また、upgrade 時の
+`connectedCallback()` が発火した初期イベントは、定義後に listener を付けるまでに失われ得る。
+
+`initializeBindings()` の公開 facade は維持し、その内部で reactive root ごとの `BindingSession` と、
+Document / ShadowRoot / structural `Content` ごとの `BindingOwner` を作る。
+既存の `scheduleDeferredApply`、deferred spread、各 handler の定義待ちは、段階的に session へ集約する。
+
+### 3.2 状態機械
+
+```text
+discovered
+  ├─ custom tag 未定義 ─> waiting-definition
+  └─ 定義済み ─────────> ready-to-attach
+
+waiting-definition ─> ready-to-attach ─> attaching ─> synchronizing ─> active
+                                           ├─ init=none ────────────> active
+
+全 phase ── contract error ─> failed
+全非終端 phase ── teardown ─> disposed
+```
+
+| phase | 実行すること | phase を抜ける条件 |
+| --- | --- | --- |
+| `discovered` | path、対象 node、明示 modifier を仮 record 化 | binding record 登録完了 |
+| `waiting-definition` | tag 単位の共有 `whenDefined()` を待つ | 定義、dispose、構造エラー |
+| `ready-to-attach` | 宣言を読み、方向・初期 authority を確定して同じ turn の cohort に集める | cohort の attach sweep 開始 |
+| `attaching` | cohort 内の producer → state listener をすべて先に登録 | cohort 全 record の listener 所有権確立 |
+| `synchronizing` | authority に従い snapshot または state 値を一度同期 | 初期同期完了 |
+| `active` | 後続 event / state update を伝播 | teardown または fatal contract error |
+| `failed` | 構造化 diagnostic を残して所有 resource を破棄 | 終端 |
+| `disposed` | listener、address、保留 callback、receipt を無効化 | 終端 |
+
+binding record は公開 `IBindingInfo` を変更せず、`WeakMap` に保持する。
+
+```ts
+type BindingPhase =
+  | 'discovered' | 'waiting-definition' | 'ready-to-attach' | 'attaching'
+  | 'synchronizing' | 'active' | 'failed' | 'disposed';
+
+type InitialAuthority = 'state' | 'element' | 'auto' | 'none';
+type ObservationPhase = 'not-applicable' | 'pending' | 'awaiting-connection' | 'synced';
+
+interface BindingRecord {
+  readonly id: number;
+  readonly info: IBindingInfo;
+  readonly generation: number;
+  phase: BindingPhase;
+  initialAuthority: InitialAuthority;
+  syncOn: 'call' | 'connect';
+  observationPhase: ObservationPhase;
+  initialAttempt: number;
+  eventSequence: number;
+  readonly teardowns: Set<() => void>;
+}
+```
+
+`phase` は binding の ownership、`observationPhase` は producer 初期観測の完了状態であり、直積として扱う。
+たとえば listener が稼働する `active` binding が `syncOn=connect` の snapshot だけを待つ状態を表現できる。
+
+`disposed` record は再利用しない。再接続・再発見時は単調増加する新しい `generation` の record を作る。
+すべての Promise continuation は捕捉した generation、期待 phase、`initialAttempt` と
+`BindingOwner.isAlive(record)` を再検査する。一致した一つの continuation だけが phase を進める。
+`isConnected` だけを生存条件にすると、mount 前の `DocumentFragment` を誤って dispose するため使わない。
+
+### 3.3 definition の待機
+
+session 内の `DefinitionCoordinator` は registry と tag の組ごとに `whenDefined()` を一度だけ登録し、待機 record を集合で
+管理する。record の dispose 時には集合から削除するため、永久に定義されない tag が DOM node を保持しない。
+現在は global registry adapter を使い、scoped custom-element registry を導入するときも coordinator の key と
+`get` / `whenDefined` / `upgrade` 呼び出しだけを差し替えられるようにする。
+
+definition 完了時、owner が保持する node がまだ disconnected subtree にある場合は、利用可能なら registry の
+`upgrade(node)` を呼んでから宣言を読み、listener を attach する。接続済みかどうかと instance が upgrade 済みかを
+同一視しない。`initializeBindingsByFragment()` は transient owner handle を内部結果へ含め、生成された `Content` が引き取る。
+mount 前は valid、`Content.unmount()` / dispose 後は invalid と判定する。
+
+`<wcs-defined>` は引き続き、アプリケーションが複数タグの registration readiness、進捗、timeout を
+観測するために使う。state runtime の正しさを DOM 上の `<wcs-defined>` の有無には依存させない。
+両者は同じ platform signal を異なる責務で使う。
+
+- `<wcs-defined>`: アプリケーション向けの集合 readiness。
+- `DefinitionCoordinator`: binding runtime 内部の個別 activation。
+
+`<wcs-defined>` の `hidden` / `display:none` は表示だけを隠し、監視対象 node の接続、`connectedCallback()`、
+binding、I/O 副作用を遅延しない。処理そのものを gate する場合は、command / effect の実行条件を
+`defined` state に依存させる。`DefinitionCoordinator` は `<wcs-defined>` の timeout / missing とは独立して待ち、
+後から tag が定義された場合も該当 binding を activation する。
+
+### 3.4 attach-first と初期 snapshot
+
+定義済み record を一つずつ attach → sync せず、同じ microtask までに ready になった record を cohort として
+二段階で処理する。未定義 tag のために root 全体を待つことはしない。
+
+1. cohort 全 record を `readBindableDeclaration()` で検査する。
+2. **attach sweep** で producer listener をすべて登録する。handler は同期的に `eventSequence` を増やし、
+   getter で抽出した値を binding 単位の ordered inbox へ積む。
+3. **producer sync sweep** で `syncOn` に従い初期 property read を inbox へ配送するか、connection 待ちを arm する。
+4. **authority sync sweep** で解決済み authority に従う。
+   - `state`: 最新 state 値を同期 scope の `WriteReceipt` 付きで local input へ適用する。
+   - `element`: producer inbox の初期 snapshot を state commit 候補にする。
+   - `none`: 初期候補を外部 state へ commit しない。
+5. `settleInitial(expectedPhase, initialAttempt)` の compare-and-set に成功した record だけを active にする。
+
+この cohort barrier により、A の初期 setter が B の event を同期発火しても、同じ ready cohort の B は既に購読済みである。
+後から定義された cohort については current property の snapshot で level state を回収する。
+
+BindingSession は cohort と authority を扱うため upstream `bind()` をそのまま呼ばず、Level 1O の observer lifecycle を
+内部 inbox に対して実装する。初期 read は custom getter を呼ばず、`name in target` で存在を判定し、明示的な
+`undefined` も配送する。upstream conformance vector をそのまま adapter test として実行する。
+
+listener 登録、初期 read、connection observer の install 中に record が throw した場合は、その record が既に登録した
+cleanup を逆順にすべて実行して `failed` にする。他 record の cohort 処理は継続する。cleanup の一件が throw しても
+残りを best-effort で続け、secondary error は diagnostic にだけ残す。初期 read 途中まで inbox へ配送済みの値は
+rollback しないという upstream の partial-delivery 契約も維持する。
+
+### 3.5 producer snapshot の `syncOn`
+
+初期 authority は「最終的に state と element のどちらを採るか」、wc-bindable の `syncOn` は「producer の
+初期 property read をいつ inbox へ配送するか」であり、別軸にする。
+
+| `syncOn` | snapshot 時点 | snapshot 前の event と競合した場合 |
+| --- | --- | --- |
+| `call`（既定） | listener attach と同じ同期 session drain | event payload を最終候補にする |
+| `connect` | unconnected `HTMLElement` が最初に接続された時 | 先行 event の後に property read を配送し、snapshot を最終候補にする |
+
+`call` では `seq0 → property read → seq1` とし、read 中の同期 event で sequence が変われば snapshot を最終候補にせず、
+event payload を残す。`connect` では接続前 event も到着順に inbox へ配送し、接続時 snapshot をその後へ enqueue する。
+connection observer と dispose は `initialAttempt` の CAS で競合させ、snapshot は高々一回にする。
+
+`syncOn=connect` は unconnected DOM element にだけ適用し、headless target、remote proxy、DOM API のない環境、未知の値は
+upstream と同じく `call` へ fallback する。wcstack では `#sync=connect` modifier を consumer option として表現し、
+wc-bindable declaration へ書き込まない。structural `Content` の明示 mount と登録済み Document / ShadowRoot observer を
+connection signal として使い、binding ごとの document-wide observer は作らない。
+
+`hasConnectedCallbackPromise` / `connectedCallbackPromise` はこの契約ではないため暗黙には待たない。
+特に `<wcs-defined>` の Promise は監視対象の完了待ちであり、timeout なしでは永久 pending になり得る。
+既定 `syncOn=call` なら 6 個の出力 property を直ちに read でき、binding は監視完了を待たない。
+
+producer 初期値は authority 判定前に internal inbox へ配送する。`init=state` ではその候補を診断可能なまま state へは
+commit せず、state input write を最終値とする。`init=element` では候補を state へ commit する。これにより observer の
+初期配送を消さずに、上位 binding policy として初期競合を解決する。
+
+初期 state setter が同期通知を返した場合、同値は receipt confirmation として抑止し、異なる値は element による
+正規化結果として queue へ積む。独立した外部 event と正規化結果は初期 write より後の変更として優先する。
+
+upgrade 中に初期イベントを取り逃しても、event 後の current property を snapshot できれば復元できる。
+イベント自体が離散的意味を持ち current property を持たない場合は replay しない。event-token / command-token は
+従来どおり離散イベントであり、定義前の空撃ちを自動再生しない。
+
+### 3.6 初期 authority を明示する
+
+初期値の競合は timing だけでは解決できない。まず wc-bindable の member direction から既定値を決め、
+双方向 member だけを主対象として binding modifier で上書きする。
+
+direction resolver は宣言 metadata と target kind を分けて扱う。local Core / Shell の `inputs` は通常の JS assignment
+surface を表すが、その assignment に Extension 1 の ack、順序、error mapping は仮定しない。remote / relay target では
+`inputs` の存在だけで代入せず、明示的な Extension-1-capable surface を経由する。
+
+| 宣言上の member | 既定 authority | 許可する明示指定 |
+| --- | --- | --- |
+| `properties` のみ（observable output） | `element` | `element`、`none` |
+| local assignment surface の `inputs` のみ | `state` | `state`、`none` |
+| local assignment surface の `properties` と `inputs` の両方 | 互換性のため `state` | `state`、`element`、`auto`、`none` |
+| Extension-1-capable surface | resolver が公開する input / output 方向 | capability の範囲内 |
+| event-token / command-token | `none` | replay しない |
+| native / manifest のない legacy element | 現行の方向推論 | `state`、`element`、`auto`、`none` |
+
+宣言済み custom element で member がどの面にも存在しない場合、または output-only へ `init=state` を指定した場合は
+contract error にする。これにより `<wcs-defined>` の `defined` / `pending` / `count` などは modifier なしで
+element authority となり、接続直後の値を必ず state へ pull できる。
+
+双方向 member の modifier は次の意味を持つ。
+
+| 指定 | 初期同期 | 用途 |
+| --- | --- | --- |
+| `init=state` | state の最新値を element へ書く | store を正とする通常の form |
+| `init=element` | listener 登録後の property snapshot を state へ入れる | SSR、declarative default、遅延 upgrade |
+| `init=auto` | state slot が未初期化なら element、それ以外は state | 段階移行用 |
+| `init=none` | 初期同期せず、次の変更から扱う | 離散入力、外部 ownership |
+
+```html
+<x-input data-wcs='value#init=state: form.name'></x-input>
+<x-clock data-wcs='value#init=element: clock.now'></x-clock>
+<wcs-defined tags='x-chart' data-wcs='defined: ready; pending: pendingTags'></wcs-defined>
+```
+
+`auto` は単なる `value !== undefined` ではなく、state slot の initialized bit で判断する。明示的に commit された
+`undefined` と未初期化を区別できる state address status API を先に導入し、未初期化なら element、それ以外は state を選ぶ。
+この API がない runtime では `auto` を有効化しない。
+
+表記は wcstack の既存 path grammar の modifier とし、wc-bindable コア宣言には追加しない。
+現行 parser は `#` 以降を modifier slot へ分離するため、`#init=state` を別 path としては解釈しない。
+ただし既存 modifier は flag 形式だけで、古い runtime は未知の `key=value` を黙って無視する。`key=value` の意味解釈と
+parser test を追加し、validator が必要な最低 runtime version を診断して silent ignore を防ぐ。
+
+### 3.7 teardown
+
+`BindingSession.dispose()` は次を同じ record の所有物として破棄する。
+
+- DOM listener と state address 登録。
+- definition / `syncOn=connect` の接続待ち continuation。Promise や observer 自体を取消せない場合も generation で無効化する。
+- 保留中の deferred apply、write receipt、trace handle。
+- DevTools へ公開した active record。
+
+`OperationTicket` は binding ではなく各 I/O node の operation owner が dispose する。binding の削除だけで、
+同じ node が別 consumer 向けに実行中の I/O を暗黙 cancel しない。
+
+wcstack 自身の構造更新では、node の置換・削除時に owner が明示的に dispose する。外部 DOM 変更に対しては
+Document / ShadowRoot ごとに一つの `MutationObserver` を持ち、mutation batch 完了後に owner から外れた subtree を
+dispose する。root 内 move は最終的な包含関係を見て維持し、登録済み root 間の move は旧 record を終端して新 generation へ
+adopt する。未知の追加 node を自動 discover する機能とは分ける。
+
+observer を使わない実装を選ぶなら、同等に pending record の強参照を解放できる ownership mechanism と、外部変更時に
+呼ぶ明示 API が必須である。`isConnected` の遅延検査だけでは、永久に定義されない tag の Promise が node を保持するため
+代替にならない。SSR / 非ブラウザ環境では owner の明示 lifecycle を使い、browser global を module 評価時に参照しない。
+
+## 4. `PropagationContext`: エコーではなく因果を追う
+
+単純な値比較だけでは、正規化された値、object の同一参照、diamond graph を区別できない。
+一方、イベントを一律に無視すると element 側の正規化結果まで失う。そこで updater の内部 queue を
+address だけでなく、値と次の context を持つ update record に変える。
+
+```ts
+interface PropagationContext {
+  readonly transactionId: number;
+  readonly originBindingId: number;
+  readonly visitedEdges: ReadonlySet<number>;
+  readonly hop: number;
+}
+
+interface WriteReceipt {
+  readonly bindingId: number;
+  readonly bindingGeneration: number;
+  readonly member: string;
+  readonly transactionId: number;
+  readonly synchronousScopeId: number;
+  readonly writtenValue: unknown;
+}
+```
+
+transaction / edge ID は session 内で一意とし、edge ID には binding generation と方向を含めて再利用しない。
+外部表示時は DevTools source ID、session ID、sequence の組へ投影する。伝播時の規則は次のとおり。
+
+1. 外部 event / API update ごとに transaction を開始する。
+2. 同じ transaction が同じ edge を再度通ろうとした場合だけ、その伝播を抑止する。
+3. element へ書く直前に member と binding generation 付きの `WriteReceipt` を同期 dynamic scope に置く。
+4. 同じ setter call stack 内で同じ member から `Object.is` 同値の通知が戻った場合だけ confirmation として再伝播を抑止する。
+5. element が値を正規化して異なる値を返した場合は、新しい edge を通る変更として継続する。
+6. transaction の hop 上限を超えた場合は、その transaction の未処理 record だけを quarantine し、既に適用した値は戻さない。
+   updater から例外は投げず、構造化 diagnostic と trace を残す。
+
+値比較は補助最適化に留め、loop 判定の根拠を edge provenance にする。primitive の `Object.is` は
+不要な setter / event を減らすため維持するが、object の深い比較を runtime の既定動作にはしない。
+
+receipt は `try/finally` で setter の同期 scope 終了時に必ず破棄する。非同期に届く event を、古い receipt と値が
+似ているだけで confirmation にしてはならない。すべての property event は internal inbox へ配送し、receipt は
+state から同じ edge へ戻すかの判断だけに使う。event-token の同 payload の複数 occurrence は一度も dedupe しない。
+
+同じ object を in-place 変更して通知する component では、reference 比較だけで confirmation と正規化を識別できない。
+また setter 後の別 task で fresh object を返す component は、core event だけでは元の write との因果を復元できない。
+その場合は component が「意味的同値なら通知しない」契約を守るか、member revision / cause token / equality を提供する
+明示的な behavioral extension が必要である。時間窓だけの pending receipt は正当な user event を誤抑止するため採用しない。
+
+### 4.1 queue の coalescing
+
+同じ address の queue が last-write-wins なら、値と correctness 用 context は最後の update の組をそのまま採用する。
+`visitedEdges` の積集合・和集合、新しい synthetic transaction への置換は、winner の通過履歴を失うため行わない。
+
+coalesce で落ちた transaction ID は、hook が有効な場合だけ bounded な trace metadata として winner に関連付ける。
+上限超過数は `truncatedParentCount` に集約し、data-plane の `PropagationContext` へ trace 用配列を持たせない。
+値を計算で merge する reducer は、入力 context を個別に保持するか、当該 address の coalescing を無効にする。
+
+context は wc-bindable の event detail や property 値へ混入させず state runtime 内部で運ぶ。非同期 operation の完了は
+開始時 transaction の `visitedEdges` を復元せず、新しい transaction として始め、開始原因は trace parent にだけ残す。
+remote 境界を越える trace context は将来の optional extension とし、未対応 peer でも値の意味が変わらないようにする。
+
+## 5. `OperationTicket`: 非同期結果に commit 権を持たせる
+
+`AbortController` だけでは、取消不能な Promise や、abort と同時に完了した結果の commit を防げない。
+非同期 I/O を lane 単位で管理し、開始時に次の ticket を発行する。
+
+```ts
+type LanePolicy = 'latest' | 'queue' | 'exhaust' | 'overlap';
+type TerminalOutcome = 'success' | 'error' | 'timeout' | 'aborted' | 'stale';
+
+interface OperationTicket {
+  readonly operationId: number;
+  readonly ownerGeneration: number;
+  readonly laneKey: string;
+  readonly policy: LanePolicy;
+  readonly supersedeEpoch?: number;
+}
+
+interface OperationAttempt {
+  readonly operationId: number;
+  readonly attempt: number;
+  readonly signal?: AbortSignal;
+}
+
+interface LaneState {
+  readonly policy: LanePolicy;
+  latestEpoch: number;
+  activeOperationId?: number;
+  readonly activeOperationIds: Set<number>;
+  readonly queue: OperationTicket[];
+  inFlightCount: number;
+}
+```
+
+| policy | 新しい要求が来たとき | commit 条件 |
+| --- | --- | --- |
+| `latest` | `latestEpoch` を進め、旧 ticket を stale にし、可能なら abort | 最新 epoch の active operation だけ |
+| `queue` | ticket を FIFO に積み、先頭だけ開始 | lane 先頭の active operation だけ |
+| `exhaust` | 実行中なら新要求を ticket 化せず拒否または既存結果へ合流 | 唯一の active operation だけ |
+| `overlap` | active set へ追加して並行実行 | active set 内の各 operation |
+
+`overlap` の active set は commit eligibility、terminal CAS、teardown、in-flight count のための内部 bookkeeping であり、
+operation ごとの observable を公開する `parallel` を意味しない。外部意味論は既存規範どおり、各完了が到着順に
+同じ観測面へ上書きする後着勝ちとする。世代は capture-only で、dispose または明示 cancel だけが無効化する。
+
+`ownerGeneration` は各 I/O Core の observe / reconnect / dispose lifecycle を表し、BindingSession generation とは
+共有しない。remote proxy の reconnect / pending response はさらに別の connection generation で管理する。
+retry は同じ `operationId` に新しい `OperationAttempt` を作り、attempt number と resource 用 signal だけを更新する。
+`overlap` の loading は単一 boolean setter ではなく `inFlightCount > 0` から導出し、複数完了の途中で false にしない。
+
+### 5.1 commit guard
+
+非同期結果から外部に見える setter、state update、event dispatch を行う直前に、共通の
+`CommitGuard` が次を検査する。判定は policy 別であり、すべてに latest の epoch 一致を要求しない。
+
+1. I/O owner lifecycle generation が一致する。
+2. operation が terminal settle 前である。
+3. `latest` は current epoch、`queue` は active head、`exhaust` は active ID、`overlap` は active set membership を満たす。
+
+browser capability は通常は開始前 precondition であり、汎用 guard に含めない。permission epoch などが実行中の妥当性を
+本当に変える node だけが、node 固有の追加 guard を登録する。binding generation も state adapter 側の別 guard である。
+
+各 operation は `pending → committing → TerminalOutcome` の一回限りの terminal CAS を持つ。成功・error・timeout の
+いずれかが `committing` を claim したものだけが公開 output を書ける。timeout は「先に失効してから error を書く」のではなく、
+eligible な ticket が timeout outcome を claim し、guard 付きで `TimeoutError` を commit してから native abort と lane 解放を行う。
+supersede / dispose は原則として公開 error を追加せず、`stale-drop` / `aborted` trace だけを残す。
+
+setter が同期 event を発火し、それが同じ lane を supersede することがあるため、guard は各 setter の直前と直後に検査する。
+直後の失効では既に発生した副作用を巻き戻さず、その operation の残りの state / event commit を止める。
+resource の節約には `AbortSignal`、正しさには owner generation・policy eligibility・terminal CAS を使う。
+
+非同期完了が state update を起こすときは新しい `PropagationContext` を開始する。開始時 transaction は ticket の
+trace parent にだけ保存し、古い `visitedEdges` は commit 側へ持ち越さない。
+
+最初の実装対象は fetch 系 node の `latest` policy に絞る。共通 abstraction が安定するまでは全 I/O package の
+必須依存にせず、各 node が小さな helper を使う。wc-bindable remote の順序、at-most-once、ack、timeout、
+backpressure は transport 境界の保証であり、UI 操作 lane の `latest` とは別レイヤーとして合成する。
+
+### 5.2 wc-bindable remote との境界
+
+- `set` は fire-and-forget の at-most-once であり、reconnect 時に自動 replay しない。
+- `setWithAck` の resolve は assignment が適用された ack であり、副作用完了や状態安定の保証ではない。reject 時は
+  server 適用済みで ack だけ失われた可能性がある。
+- `invoke` は Extension-1-capable surface の command 呼出しである。応答喪失時の自動再送で at-least-once に変えず、
+  再試行が必要な非冪等 command は application の idempotency token で重複排除する。
+- 単一 logical channel の caller order / FIFO と local lane policy は別であり、remote FIFO だけで stale UI commit は防げない。
+- timeout / `AbortSignal` は client の pending wait を解放するだけで、server side effect を停止しない。遅い response は
+  connection generation と pending map で drop する。
+- pre-open、pre-sync、pending invocation、sync update の各 buffer は独立に上限と overflow policy を持つ。
+- ordinary wire value は `JsonValue` に限定する。top-level observable `undefined` は capability-gated な out-of-band 表現を使い、
+  nested `undefined` は送らない。
+- `sync.capabilities` は connection ごとの remote behavioral capability で、declaration の `inputs` / `commands`、
+  browser API capability、sidecar extension と同一視しない。
+- declaration fingerprint は interface identity / resync 用であり、trace ID、認可、署名には使わない。
+
+## 6. DevTools trace は side channel にする
+
+既存 DevTools hook を拡張し、少なくとも次の構造化 record を送る。
+
+| category | 主な event |
+| --- | --- |
+| binding lifecycle | `binding:discovered`、`binding:attached`、`binding:snapshot`、`binding:disposed` |
+| propagation | `propagation:applied`、`propagation:coalesced`、`propagation:suppressed`、`propagation:hop-limit` |
+| async I/O | `io:operation-started`、`io:operation-retried`、`io:operation-settled`、`io:stale-dropped` |
+| contract | `contract:manifest-read`、`contract:unsupported-extension`、`platform:capability-missing` |
+
+全 record は monotonic timestamp、DevTools source ID、source-local sequence を持つ。該当時だけ trace / parent ID、
+root / session / binding / edge ID、operation ID、lane を付ける。data-plane の transaction / visited edge と
+trace ID は別に採番し、hook 接続状態で correctness context の形を変えない。command-token が同期的に起こす update は
+call scope の trace parent を継承し、非同期完了は新しい data transaction と既存 operation の trace parent を使う。
+
+既定では property 値、event detail、command 引数、URL、header、response body を保存しない。
+必要な場合だけ利用者が redactor / serializer を明示登録する。serializer は hot path ではなく trace drain 側で実行し、
+例外、depth、出力 byte 数、実行時間を制限する。getter 関数本体や live handle は直列化しない。
+
+data hot path は subscriber を同期呼出しせず、bounded ring buffer への append と drain schedule だけを行う。
+consumer drain は microtask または animation frame へ分離し、各 callback 例外を bridge で隔離する。buffer overflow は
+trace record だけを drop し、drop count を次の record に載せる。hook subscriber がない hot path では trace record object を
+生成しない。
+
+DevTools を後から接続したときは、`kind: state` / `kind: io` など additive な source ごとの snapshot callback から、
+既存 session、binding phase、active operation の baseline を一度送り、以降を差分にする。operation controller は active な間だけ
+列挙 registry へ登録し、settle / dispose 時に解除する。古い consumer は未知 source kind と event namespace を無視する。
+subscriber の例外、遅延、再入、切断がデータ面の順序や結果を変えてはならない。
+
+この trace により、複数 node にまたがる一つの操作を、原因 → binding edge → I/O ticket → commit / stale-drop の
+一本の timeline として表示できる。remote peer との分散 trace はコア payload へ独自 field を混ぜず、将来の
+optional extension が双方で合意された場合だけ接続する。
+
+## 7. `wcstack.manifest.json`: 静的契約を sidecar に置く
+
+wc-bindable の `static wcBindable` は browser runtime が読む実行時の事実として維持する。型、lane policy、
+必要 browser API までコア宣言へ詰め込まず、optional sidecar に置く。用語は次の四つに分離する。
+
+- behavioral extension: 公式 wc-bindable Extension 1 / 2。
+- manifest extension: sidecar 内の `wcstack.*` namespace。
+- remote capability: connection の `sync.capabilities`。
+- platform capability: browser / runtime API とその利用条件。
+
+package component contract と application state schema は同じ envelope version を共有できるが、別 artifact にする。
+次は package 側の例である。
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "package",
+  "bindingProtocol": {
+    "protocol": "wc-bindable",
+    "minimumVersion": 1
+  },
+  "behavioralRequirements": {
+    "required": [],
+    "optional": ["wc-bindable/extension-1"]
+  },
+  "manifestExtensions": {
+    "wcstack.types": {
+      "version": 1,
+      "components": {
+        "wcs-fetch": {
+          "observables": {
+            "response": {
+              "event": "wcs-fetch:response",
+              "schema": { "type": ["object", "null"] }
+            }
+          },
+          "inputs": {
+            "url": { "schema": { "type": "string" } }
+          },
+          "commands": {
+            "fetch": {
+              "args": { "type": "array" },
+              "result": {}
+            }
+          }
+        }
+      }
+    },
+    "wcstack.async": {
+      "version": 1,
+      "components": {
+        "wcs-fetch": {
+          "operations": {
+            "fetch": { "lane": "request", "policy": "latest" }
+          }
+        }
+      }
+    },
+    "wcstack.platformCapabilities": {
+      "version": 1,
+      "components": {
+        "wcs-fetch": {
+          "required": ["web.fetch"],
+          "optional": ["web.abort-controller"]
+        }
+      }
+    }
+  }
+}
+```
+
+application artifact は `kind: application` とし、root `stateSchema`、filter の input / output、list context を持つ。
+package と application を同じ file へ merge せず、validator が package contract を解決して application binding と照合する。
+
+型表現は arbitrary TypeScript 文字列ではなく、JSON Schema の明示 subset に限定する。最初は `type`、`properties`、
+`required`、`items`、`enum`、`const`、`anyOf`、`$defs` と local `$ref` を対象とし、external `$ref` は禁止する。
+resolver は cycle を検出し、未知 keyword は runtime で推測せず、IDE / CI で unsupported diagnostic にする。
+
+literal path、array wildcard、nested list context、filter chain、command arguments / result を schema で照合し、
+動的に構築された path は `unknown` へ落として runtime の動作を妨げない。sidecar に member があるのに実行時宣言にない、
+または event 名が異なる場合は CI で drift error にする。実行時の live declaration を sidecar が上書きすることはない。
+同様に `wcstack.async` は tooling 向けの記述であり、実際の lane policy と commit guard は I/O Core のコードを正とする。
+sidecar がない、または古いことを理由に runtime の競合防止を無効化しない。
+`behavioralRequirements` も必要 extension を記述するだけで、target を Extension-1-capable に変えない。runtime discovery と
+capability negotiation の結果を validator / adapter が別途照合する。
+
+package が TypeScript 型を authoring source にする場合も、公開 artifact は deterministic generator が出力した同じ JSON schema とし、
+CI で再生成差分を検査する。application artifact の探索、package 解決、同名 tag / filter の衝突、override 禁止／許可を
+schema 文書で固定し、暗黙の last-file-wins merge は行わない。
+
+### 7.1 validator を一つにする
+
+`packages/vscode-wcs/src/service` から、DOM に依存しない parser・path resolver・schema checker を pure library として
+切り出す。同じ validator core を次から呼ぶ。
+
+- VS Code: 編集中の diagnostic、completion、hover。
+- CI CLI: repository 全体の path、modifier、manifest drift 検査。
+- development runtime: 実際に読み込まれた宣言との optional 検査。
+
+diagnostic は安定した code、source range、severity、関連する tag / member / state path を持つ。
+未知の型と動的 path は warning または情報、確実な型不一致、存在しない member、壊れた manifest は error とする。
+これにより IDE だけが知る規則と runtime だけが知る規則の分岐を防ぐ。
+
+### 7.2 capability の判定
+
+sidecar は必要能力を静的に列挙するが、実際の可否は User-Agent ではなく利用直前の feature detection で決める。
+
+```ts
+interface PlatformAssessment {
+  readonly availability: ReadonlyMap<string, 'available' | 'missing' | 'unknown'>;
+  readonly permission: 'granted' | 'denied' | 'prompt' | 'not-applicable' | 'unknown';
+  readonly readiness: 'idle' | 'ready' | 'degraded';
+  readonly activity: 'inactive' | 'active';
+  readonly preconditions: {
+    readonly secureContext: 'satisfied' | 'required' | 'not-applicable';
+    readonly userActivation: 'present' | 'required' | 'not-applicable';
+  };
+  readonly epoch: number;
+  readonly lastError?: WcsIoErrorInfo;
+}
+
+interface WcsIoErrorInfo {
+  readonly code: string;
+  readonly phase: 'probe' | 'start' | 'execute' | 'decode' | 'commit' | 'dispose';
+  readonly recoverable: boolean;
+  readonly capabilityId?: string;
+  readonly message: string;
+}
+```
+
+availability、permission、readiness、activity、operation error を一つの `ready / unsupported / error` enum に畳まない。
+required API が欠ける場合は操作を開始せず、optional API が欠ける場合は宣言済み fallback に切り替えて readiness を
+`degraded` にする。permission / policy 拒否、network、timeout、abort、decode、内部 contract violation は別 code にする。
+
+platform capability ID は built-in の `web.fetch` のような安定 namespace とし、third-party は reverse-DNS namespace を使う。
+registry は ID ごとに side-effect-free presence probe、必要なら secure-context / activation / permission 条件、browser compatibility
+dataset key を対応付ける。`web.fetch` の文字列をそのまま global property path として eval しない。
+
+probe は module 評価時には行わない。activation 時に baseline を取り、各 operation の直前に利用条件を再検査する。
+permission change、device removal、visibility / BFCache など platform notification がある場合は observer で epoch を更新し、
+dispose 時に解除する。実行中 validity を変える node だけがこの epoch を node 固有の commit guard に使う。
+
+runtime の `WcsIoError` は上の serializable info と non-cloneable な `cause` を分け、DevTools / remote へは info だけを投影する。
+初期移行では既存 error property / event の値 shape を変更せず、taxonomy は DevTools と opt-in `errorInfo` へ出す。
+既存 output を `WcsIoError` に置換する場合は package ごとに互換性を判定し、必要なら major change とする。
+
+### 7.3 version 軸を混同しない
+
+| 軸 | 役割 | 互換規則 |
+| --- | --- | --- |
+| npm SemVer | package の配布・API | package ごとの SemVer |
+| wc-bindable `version` | コア宣言形式 | 整数 1 以上を受理し、未知 optional field を無視 |
+| behavioral extension / remote capability | command execution と wire behavior | extension contract と connection capability bit で検査 |
+| manifest extension `version` | `wcstack.types` 等の sidecar 語彙 | namespace ごとに対応 range を検査 |
+| sidecar `schemaVersion` | manifest envelope | reader が対応 major を明示 |
+
+必須 behavioral extension が未対応なら、その機能だけを activation error にする。optional behavioral / manifest extension は
+無視してコア property binding を継続する。破壊的なコア意味変更は高い整数 version の推測で扱わず、
+新しい protocol identifier を使う。
+release test では「新 reader × 旧宣言」「旧 reader × 新 optional field」「対応／未対応 extension」の
+互換 matrix を固定 fixture として持つ。
+
+## 8. 段階導入
+
+一度に runtime 全体を書き換えず、各 phase を release checkpoint にする。ただし後続 phase は先行 foundation に依存するため、
+rollback は原則として末尾 phase から行い、後続を残したまま phase 0 / 1 だけを戻さない。
+
+| phase | 実装 | 完了条件 |
+| --- | --- | --- |
+| 0. foundation | repository-local discovery mirror / 公式 helper を oracle とする conformance fixture、最小 platform guard、version 型 | 現行 v1 が不変で、version 2＋未知 optional field、SSR import、公開 ESM の外部 runtime import なしが通る |
+| 1. lifecycle ownership | `BindingSession`、`DefinitionCoordinator`、record / teardown。同期順序はまだ現行互換 | listener / address の重複がなく、未定義中の削除・再接続 test が通る |
+| 2. 初期同期 | ready cohort、`syncOn`、direction 決定表、`init` modifier | upstream observer vectors と `wcs-defined` を含む race test が決定的に通る |
+| 3. 因果伝播 | update record、`PropagationContext`、`WriteReceipt` | echo、正規化、diamond、coalescing test が通る |
+| 4. 非同期・trace | 全 policy の lane unit、fetch `latest` PoC、terminal CAS、非同期 trace queue | stale commit 0、hook off の性能 gate 合格 |
+| 5a. 静的契約 | sidecar schema、validator core、VS Code / CI integration | IDE と CI の diagnostic code / range が一致 |
+| 5b. 開発時照合 | opt-in runtime analyzer と manifest drift trace | 無効時の runtime 挙動・cost が不変 |
+| 6. capability | probe / report / error taxonomy を I/O package へ順次適用 | 対象 browser matrix と SSR import test が通る |
+
+phase 1 では既存 `initializeBindings()` と `initializeBindingsByFragment()` の signature を facade として維持する。
+phase 2 の output-only initial read と新 modifier は feature flag 下で既存 example / SSR snapshot を比較してから既定化する。
+phase 3 までは primitive same-value guard を残し、provenance と結果が一致することを shadow diagnostic で確認する。
+phase 4 の lane policy は fetch 系から始め、node ごとの固有 cancellation / retry 契約を一括変換しない。
+phase 0 の最小 platform guard は global の存在確認と owner adapter だけを提供し、phase 6 の capability taxonomy と混同しない。
+
+各 phase の旧経路と新経路を同じ binding に二重適用してはならない。session 単位で ownership を切り替え、
+rollback 時も listener、address、operation ticket の所有者が常に一つになるようにする。依存順は
+`foundation → lifecycle → initial sync → propagation` と、`foundation → operation / trace → sidecar / capability` の二系統である。
+
+## 9. 主な変更箇所
+
+| 領域 | 現在の入口 | 設計上の変更 |
+| --- | --- | --- |
+| 宣言解釈 | `packages/state/src/protocol/wcBindable.ts` と各判定箇所 | repository-local conformance mirror を runtime gate、公式 helper を test oracle とし、型と dev analyzer を追加 |
+| binding lifecycle | `bindings/initializeBindings.ts`、`collectNodesAndBindingInfos.ts` | facade の内側に session、owner、record、cohort drain を置く |
+| 遅延定義 | `apply/scheduleDeferredApply.ts`、deferred spread、`event/twowayHandler.ts` | 個別 `whenDefined()` を coordinator へ移し、attach / sync の所有権を一本化 |
+| update pipeline | `updater/updater.ts`、`proxy/apis/postUpdate.ts`、`proxy/methods/setByAddress.ts` | address queue を context 付き update record へ拡張 |
+| DOM apply | `apply/applyChangeToProperty.ts` ほか | receipt、binding generation、propagation context を apply context へ渡す |
+| DevTools | `state/src/devtools/{types,sink,bridge}.ts` と `packages/devtools` | lifecycle / propagation / operation record と baseline snapshot を追加 |
+| async PoC | `packages/fetch/src/core/FetchCore.ts` | request lane に `latest` ticket と commit guard を導入 |
+| static validation | `packages/vscode-wcs/src/service` | pure validator core を分離し VS Code / CI / dev runtime から共有 |
+| browser variance | 各 I/O Core / Shell | platform assessment と互換な `WcsIoErrorInfo` 投影を package ごとに移行 |
+
+`IBindingInfo` は収集結果として維持し、session 固有の可変状態を追加しない。公開 component API、wc-bindable の
+property event payload、command 引数はこの変更箇所表の対象外とし、既存利用者の wire contract を保つ。
+
+## 10. 検証設計
+
+順序問題は wall-clock sleep で検証せず、制御可能な custom-element registry、Promise、microtask drain、
+fake transport を使う。`BindingSession` の reducer / transition は model-based test にし、define、event、state write、
+dispose、reconnect の並びを生成して次の不変条件を検査する。
+
+1. 一つの record / generation につき listener、address、初期同期は高々一回。
+2. active / failed / disposed 以外で settle した初期 attempt は存在しない。
+3. disposed generation から DOM / state への commit はない。
+4. 同じ transaction / edge は二度適用されず、異なる正規化値は失われない。
+5. commit 権のない async ticket は外部可視状態を変更しない。
+6. install 途中の throw でも、その record が登録済みの全 resource が best-effort で解除される。
+7. trace subscriber の throw、遅延、overflow は data-plane の結果を変えない。
+
+### 10.1 論点別の必須ケース
+
+| 論点 | 必須回帰 test |
+| --- | --- |
+| 1. 定義順序 | registry + tag ごとの待機一回、invalid tag、define 前 expando、複数 root、待機中削除、root dispose 後 define、fragment upgrade / adopt |
+| 2. 初期配送 | upstream observer vectors、`syncOn=call/connect`、connect 前 dispose / reconnect、明示 `undefined`、read 中 event、partial read throw、A setter → B event |
+| 3. エコー | 同期 confirmation、正規化差分、同一 object 制約、delayed fresh-object echo の extension 要求、同 payload occurrence、diamond、last-wins coalescing |
+| 4. 非同期競合 | `latest/queue/exhaust/overlap`、overlap の後着勝ち、per-operation observable なし、in-flight count、abort 無視、追い越し、setter 中 supersede、terminal CAS、retry、timeout 後成功、dispose 中完了 |
+| 5. デバッグ | parent chain、late baseline、detach、ring overflow / drop count、serializer throw / limit、未知 source、remote trace capability なし、hook 例外隔離 |
+| 6. path 型 | nested / array wildcard / list context、filter chain、command arity、readonly、reserved / inherited name、dynamic path、malformed `$ref`、artifact merge / drift |
+| 7. browser 差 | API 一部欠如、insecure context、user activation、permission 変更、device busy / removal、visibility / BFCache、late callback、SSR、error info cloneability |
+| 8. 互換性 | version 1 / 2 / 0 / 負数 / 非整数 / NaN、old/new reader × declaration、local / remote、Extension 1 不可、reconnect / fingerprint 変更、別 protocol ID |
+
+### 10.2 `<wcs-defined>` を使う統合ケース
+
+- 全対象 tag が定義済みで、binding attach 前に初期 `change` が出ても `defined` / `count` を即時 snapshot できる。
+- 未定義 tag、`timeout=0` で `connectedCallbackPromise` が pending のままでも、`pending` を pull して session は active になる。
+- timeout 後の遅延 define で `missing → count` が一回だけ反映され、古い continuation は no-op になる。
+- output-only direction が自動的に element authority となり、既定 `syncOn=call` が監視完了 Promise を待たない。
+- 明示 `syncOn=connect` は DOM connection だけを待ち、connect 前 event → snapshot の順序と connect 前 dispose を保証する。
+- `init=state` setter の同期 event は receipt で confirmation / normalization に分類される。
+- `hidden` な `<wcs-defined>` も接続・binding 済みであり、実行 gate ではない。
+
+### 10.3 性能・保持 gate
+
+採択前に現行 main の benchmark を固定し、少なくとも次を gate にする。割合は初回 baseline 計測後に確定するが、
+暫定上限は初期化時間・steady-state update とも p95 で 10% regression とする。
+
+- DevTools hook がない場合、trace record / payload serialization の allocation は 0。
+- 同一 session / tag の platform `whenDefined()` 登録は 1。
+- 10,000 binding の collect → attach → sync と、10,000 update の drain を別々に測る。
+- 100 回の attach / dispose 後、record、node、listener、receipt、ticket が到達不能になることを heap test で確認する。
+- root observer と同等 ownership 実装を比較し、外部 mutation なしの steady-state cost、大量削除、root 間 move を測る。
+- active operation source registry が terminal / dispose 後に空になり、late attach baseline のためだけに Core を保持しない。
+- provenance 無効化を逃げ道にせず、必要なら compact ID、copy-on-write edge set、record pooling で overhead を下げる。
+
+## 11. 実装前の decision gate
+
+| 判断 | 推奨初期値 | 決定時点 |
+| --- | --- | --- |
+| `init` / `syncOn` modifier の最終 syntax | `#init=state` / `#sync=connect`。現行 `#` slot と構文衝突はなく、`key=value` 解釈と最低 runtime version 診断を追加 | phase 2 着手前 |
+| output-only の producer initial read | 採択。既定は`syncOn=call`、明示時だけ`connect` | phase 2 |
+| 双方向 member の既定 authority | 現行互換の `state`。`auto` は明示 opt-in | phase 2 |
+| 正規化差分 | element の確定値として受理し、receipt confirmation とは分ける | phase 3 |
+| 非同期・same-reference echo | core だけでは完全識別不能。実例が必要なら revision / cause extension を別設計 | phase 3 |
+| 外部 DOM mutation の teardown | root observer を既定候補とし、採らない場合も同等の強参照解放 mechanism を必須化 | phase 1 終了時 |
+| component 固有 readiness 拡張 | 初期 release では実装せず、公式 `syncOn` で扱えない実例が揃ってから設計 | phase 2 後 |
+| sidecar の探索・merge 規則 | package artifact と app artifact を分離し、衝突を schema 文書で固定 | phase 5a 着手前 |
+| error taxonomy の公開面 | 既存 error shape を維持し、まず DevTools / opt-in `errorInfo` | phase 6 |
+| trace buffer | bounded ring、payload なしを既定。上限は browser memory benchmark で決定 | phase 4 |
+
+特に component readiness を `connectedCallbackPromise` の存在だけで自動有効化しないことは、decision ではなく不変条件とする。
+また sidecar の optional 情報を runtime correctness の必須入力に格上げしない。
+
+## 12. 非目標
+
+- listener 登録前に発生した離散 event / command を永続ログから replay すること。
+- revision / cause を持たない非同期 property event を、正当な user 変更と programmatic echo へ完全分類すること。
+- DOM、worker、remote peer をまたぐ exactly-once 分散 transaction を提供すること。
+- object の deep equality や immutable data model をすべての binding に強制すること。
+- `<wcs-defined>` を autoloader、DOM 接続 barrier、binding scheduler に変えること。
+- browser API の不足を全 package で polyfill すること。
+- TypeScript 固有の型式を browser runtime に必須化すること。
+- 一回の release で全 I/O node の cancellation / retry policy を統一すること。
+- wc-bindable コアへ wcstack 固有の trace、型、lane field を追加すること。
+
+## 13. 参照
+
+- [論点一覧](README.md#論点一覧)
+- [タグ定義とバインディング確立の順序](01-binding-initialization-order.md)
+- [接続直後の初期状態配送](02-initial-state-delivery.md)
+- [双方向バインディングのエコー制御](03-two-way-echo-control.md)
+- [非同期実行と wc-bindable 境界](04-async-execution-and-wc-bindable.md)
+- [観測性・デバッグと wc-bindable 境界](05-observability-and-wc-bindable.md)
+- [パス文字列の型安全性](06-path-type-safety.md)
+- [ブラウザ capability 差の吸収](07-browser-capability-variance.md)
+- [プロトコル進化と互換性](08-protocol-evolution.md)
+- [`<wcs-defined>` 設計メモ](../defined-tag-design.md)
+- [DevTools hook protocol](../devtools-hook-protocol.md)
+- [wc-bindable SPEC（2026-07-14 確認・固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC.md)
+- [wc-bindable Extensions（同固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC-extensions.md)
+- [wc-bindable remote README（同固定コミット）](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/packages/remote/README.md)

--- a/docs/architecture-hardening/README.md
+++ b/docs/architecture-hardening/README.md
@@ -1,0 +1,70 @@
+# wcstack アーキテクチャ難所の堅牢化
+
+- **作成日**: 2026-07-14
+- **状態**: 設計提案（未採択。本文書群だけでは実行時挙動を変更しない）
+- **対象スナップショット**:
+  - wcstack: `27371dca55888c864028042e71d8a7e7149365b4`（v1.20.0）
+  - wc-bindable-protocol: `5ec0deef212578a072b2f669d2a5554f254253e0`
+  - npm 公開版: `@wc-bindable/core@0.8.0`
+
+## 目的
+
+wcstack は、リアクティブコア、UI、I/O ノードを共通プロトコルで疎結合にする。
+交換可能性が高い一方、初期化順序、双方向伝播、非同期実行、観測性などの難しさも
+境界上に現れる。本ディレクトリは、その難所を個別に分解し、現状、未解決点、推奨する
+対策、互換性、検証条件を記録する。
+
+本文書群は設計判断の材料であり、記載した API やメタデータは未実装である。
+既存の規範文書と矛盾する場合は、採択と実装に先立って当該規範文書を更新する。
+
+## 論点一覧
+
+1. [タグ定義とバインディング確立の順序](01-binding-initialization-order.md)
+2. [接続直後の初期状態配送](02-initial-state-delivery.md)
+3. [双方向バインディングのエコー制御](03-two-way-echo-control.md)
+4. [非同期実行と wc-bindable 境界](04-async-execution-and-wc-bindable.md)
+5. [観測性・デバッグと wc-bindable 境界](05-observability-and-wc-bindable.md)
+6. [パス文字列の型安全性](06-path-type-safety.md)
+7. [ブラウザ capability 差の吸収](07-browser-capability-variance.md)
+8. [プロトコル進化と互換性](08-protocol-evolution.md)
+
+## 8 論点を横断する修正設計
+
+- [8 論点を横断する修正設計](09-remediation-design.md) — `BindableDeclarationReader`、
+  `BindingSession`、`PropagationContext`、`OperationTicket`、`wcstack.manifest.json` の責務分割、
+  段階導入、回帰テスト、decision gate をまとめる。
+
+## 横断原則
+
+1. **暗黙の時刻依存を、明示的なフェーズまたは状態へ変える。**
+2. **初期スナップショットと後続イベントを分ける。**
+3. **値、イベント、コマンド、ライブハンドルの意味を混ぜない。**
+4. **正しさは世代・所有権・順序契約で担保し、キャンセル API だけに依存しない。**
+5. **本番コストを増やさず、開発時には因果関係を観測可能にする。**
+6. **ビルドレスを維持し、型検査と capability 情報は漸進的に追加する。**
+7. **既存プロトコルの意味を変更せず、追加情報は後方互換な形で表現する。**
+
+## wc-bindable の参照方針
+
+論点 4・5 は、wcstack 内の `static wcBindable` 宣言だけでなく、公式
+wc-bindable-protocol の最新仕様を参照する。特に次を前提とする。
+
+- コアの `properties` は producer から consumer への観測面である。
+- `inputs` と `commands` はコアでは宣言メタデータであり、呼び出し意味論は拡張仕様に属する。
+- 初期同期、teardown、forward compatibility はコア仕様の規範である。
+- remote の ack、順序、timeout、AbortSignal、back-pressure、wire capability は拡張仕様の規範である。
+- デバッグ計装はコアの観測意味論を変えず、別の side channel として設計する。
+
+参照先は更新による意味のずれを避けるため、本文書作成時のコミットに固定する。
+
+- [wc-bindable SPEC.md](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC.md)
+- [wc-bindable SPEC-extensions.md](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/SPEC-extensions.md)
+- [wc-bindable remote README](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/packages/remote/README.md)
+- [wc-bindable CONFORMANCE.md](https://github.com/wc-bindable-protocol/wc-bindable-protocol/blob/5ec0deef212578a072b2f669d2a5554f254253e0/CONFORMANCE.md)
+
+## 採択の進め方
+
+各文書の提案は独立に採択できる。ただし、初期同期に関する 1・2、実行と観測に関する
+4・5、型情報とプロトコル進化に関する 6・8 は相互依存する。実装へ進む際は、各文書の
+「決定ゲート」を先に確定し、[8 論点を横断する修正設計](09-remediation-design.md) の phase と適合テストを
+実装の完了条件に含める。


### PR DESCRIPTION
- Introduced a new document outlining the architecture hardening proposal for wcstack.
- Details the purpose, key issues, and remediation design principles.
- Lists references to the wc-bindable protocol specifications and outlines the adoption process for the proposed changes.