### PR TITLE
feat(conformance): gate settable wcBindable members against missing inputs declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,22 @@ jobs:
       - run: node scripts/sync-io-core.mjs --check
       - run: node scripts/sync-package-configs.mjs --check
 
+  bindable-conformance:
+    # settable wcBindable member ⇒ declared in inputs. A runtime check that
+    # imports each package's committed dist bundle and inspects the *evaluated*
+    # declaration against the prototype chain's setters — so dynamically
+    # generated wcBindable surfaces are covered too, which no source lint can
+    # see (the router navigateUrl / DCC $bindables class of drift). Committed
+    # dist lags src between releases; release.yml re-runs the same script after
+    # the version-bump rebuild so fresh bundles are re-gated before publish.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/conformance-bindable-inputs.mjs
+
   wcs-validate:
     # Phase 5a 静的契約の CI ゲート。vscode-wcs の validator core を wcs-validate CLI
     # 経由で repo の HTML / sidecar manifest に適用し、error severity の診断があれば

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,13 @@ jobs:
             echo "::endgroup::"
           done
 
+      # Last gate before publish: settable wcBindable member ⇒ declared in inputs.
+      # Runs against the freshly rebuilt bundles, so src-introduced declaration
+      # drift (the router navigateUrl / DCC $bindables class of bug) cannot ship
+      # even though the CI job only sees committed dist.
+      - name: Bindable settable-surface conformance (rebuilt dist)
+        run: node scripts/conformance-bindable-inputs.mjs
+
       # Commit release artifacts locally so npm publish uses the same tree that will be tagged.
       - name: Commit release artifacts
         run: |

--- a/docs/architecture-hardening/10-defaulting-rollout-status.md
+++ b/docs/architecture-hardening/10-defaulting-rollout-status.md
@@ -184,4 +184,5 @@ phase 実装（PoC）は 0-6 すべて完了済み。局面は既定化・横展
 - errorInfo 実装済み **27 パッケージ** = `grep -rl errorInfo packages/*/src/exports.ts`（横展開前の初期値は 8）。
 - lane 生成コピー保有 6 パッケージ = `packages/*/src/core/operationLane.ts`。`sync-io-core.mjs --check` = 33 生成ファイル整合。
 - CI の architecture-hardening 関連ステップは `sync-io-core.mjs --check` に加え、独立 job **`wcs-validate`**（§B で追加。examples + packages の HTML を error severity で gate、現状 0 error）。
+- 2026-07-17 追加: 独立 job **`bindable-conformance`**（`scripts/conformance-bindable-inputs.mjs`）— 「settable な wcBindable メンバは `inputs` にも宣言する」不変条件を、dist バンドルを import した**評価済み宣言** × プロトタイプチェーン setter の突合で検査（41 pkg / 79 class / 441 メンバ）。ソース lint と違い動的生成宣言もカバーし、v1.20.0 router に対して `navigateUrl` を検出することを実証済み（router navigateUrl / DCC `$bindables` 型ドリフトの恒久ガード）。committed dist は src に遅行するため、release.yml でも bump 後 rebuild 直後・publish 前に同 script を再実行して補完。意図的 output-only（`Router.path` / `StorageCore.value`）は script 内 allowlist に理由付きで記録。dist export に現れない宣言ファクトリ（DCC `createWcBindable`）は state の unit test が固定。
 - Phase 2 flip は commit `aaeb784`（メッセージは "geolocation errorInfo" と実態を過小記述、state 変更を混載）に含まれる。

--- a/scripts/conformance-bindable-inputs.mjs
+++ b/scripts/conformance-bindable-inputs.mjs
@@ -1,0 +1,169 @@
+// wcstack wc-bindable settable-surface conformance check.
+//
+// Invariant (state README "Binding Authority (#init= / #sync=)"): a wcBindable
+// member that is settable — the class prototype chain defines a setter for it —
+// MUST also be declared in `inputs`. A settable member declared only in
+// `properties` is classified output-only under directional initial sync
+// (default on since v1.21.0): state→element writes are permanently suppressed
+// and the element's initial value overwrites the state seed. This exact drift
+// shipped twice — router navigateUrl (fixed in v1.21.0) and DCC $bindables
+// (createWcBindable, fixed post-v1.21.0).
+//
+// Unlike conformance-io-nodes.mjs (a regex source lint), this check IMPORTS
+// each package's built bundle and inspects the *evaluated* declaration, so
+// dynamically generated wcBindable surfaces are covered too — the reason the
+// DCC drift escaped every grep-based sweep.
+//
+// It reads committed dist/ bundles. In CI it gates the checked-in artifacts;
+// release.yml runs it again after the version-bump rebuild so freshly built
+// bundles are re-gated right before npm publish.
+//
+// Known limitations:
+// - Members implemented as instance data fields (no prototype accessor) are
+//   invisible without instantiation; classes are never instantiated here.
+//   Shell/Core members are prototype accessors by convention.
+// - Only classes reachable from dist exports are covered. Declaration factories
+//   that never surface a class through exports — DCC's createWcBindable in
+//   @wcstack/state — are locked by that package's own unit tests instead
+//   (dcc.wcBindable.test.ts: properties/inputs member sets must match).
+//
+// Run:  node scripts/conformance-bindable-inputs.mjs
+// Exit 1 on any non-allowlisted violation.
+
+import { existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PKGDIR = join(ROOT, "packages");
+
+// Documented deviations: members that keep a setter but are deliberately
+// output-only. Key: "<pkg>:<ClassName>.<member>". Every entry needs a reason
+// traceable to a design doc or inline comment.
+const OUTPUT_ONLY_WITH_SETTER = {
+  // The setter is applyRoute's internal write path (stores + dispatches the
+  // change event, never navigates); programmatic navigation goes through
+  // navigateUrl. Deliberately output-only
+  // (docs/architecture-hardening/10-defaulting-rollout-status.md §D).
+  "router:Router.path": "setter is applyRoute's internal write path and never navigates; navigation goes through navigateUrl",
+  // Core-level omission is deliberate: persistence happens only via save() /
+  // remove(), and the Shell (manual mode) is the surface that stages a value
+  // handed in via a `value` binding — the Shell declares `value` in inputs
+  // (comment above StorageCore._setValue).
+  "storage:StorageCore.value": "staging surface is the Shell, which declares value in inputs; Core setter is Shell plumbing",
+};
+
+// ---- minimal DOM shim (import-time only; classes are never instantiated) ----
+class HTMLElementShim {}
+if (typeof globalThis.HTMLElement === "undefined") globalThis.HTMLElement = HTMLElementShim;
+if (typeof globalThis.customElements === "undefined") {
+  globalThis.customElements = {
+    define() {},
+    get() { return undefined; },
+    whenDefined() { return new Promise(() => {}); },
+  };
+}
+
+function isBindableClass(value) {
+  return typeof value === "function"
+    && typeof value.wcBindable === "object"
+    && value.wcBindable !== null
+    && value.wcBindable.protocol === "wc-bindable";
+}
+
+// Nearest descriptor wins: a getter-only accessor on a nearer prototype shadows
+// any setter further up the chain, so assignment through it fails anyway.
+function nearestDescriptor(cls, name) {
+  let proto = cls.prototype;
+  while (
+    proto
+    && proto !== Object.prototype
+    && proto !== EventTarget.prototype
+    && proto !== globalThis.HTMLElement.prototype
+  ) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+    if (descriptor) return descriptor;
+    proto = Object.getPrototypeOf(proto);
+  }
+  return null;
+}
+
+// ---- run ----
+const packages = readdirSync(PKGDIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .filter((name) => existsSync(join(PKGDIR, name, "dist", "index.esm.js")));
+
+let classesChecked = 0;
+let membersChecked = 0;
+const violations = [];
+const deviations = [];
+const importFailures = [];
+const rows = [];
+
+for (const pkg of packages) {
+  const bundle = join(PKGDIR, pkg, "dist", "index.esm.js");
+  let moduleExports;
+  try {
+    moduleExports = await import(pathToFileURL(bundle).href);
+  } catch (error) {
+    importFailures.push({ pkg, message: String(error?.message ?? error) });
+    continue;
+  }
+
+  const classes = new Set(Object.values(moduleExports).filter(isBindableClass));
+  const flagged = [];
+  for (const cls of classes) {
+    classesChecked++;
+    const declaration = cls.wcBindable;
+    const inputNames = new Set((declaration.inputs ?? []).map((input) => input.name));
+    for (const property of declaration.properties ?? []) {
+      const name = property.name;
+      membersChecked++;
+      if (inputNames.has(name)) continue;
+      const descriptor = nearestDescriptor(cls, name);
+      if (!descriptor || typeof descriptor.set !== "function") continue;
+      const key = `${pkg}:${cls.name}.${name}`;
+      const reason = OUTPUT_ONLY_WITH_SETTER[key];
+      if (reason) {
+        deviations.push({ key, reason });
+        flagged.push(`◇ ${cls.name}.${name}`);
+      } else {
+        violations.push({ key, pkg, cls: cls.name, name });
+        flagged.push(`✗ ${cls.name}.${name}`);
+      }
+    }
+  }
+  rows.push({ pkg, classes: classes.size, flagged });
+}
+
+// ---- print ----
+console.log("\n=== wc-bindable settable-surface conformance (settable ⇒ declared in inputs) ===");
+console.log("(runtime check over dist bundles · ✗ violation · ◇ documented output-only deviation)\n");
+for (const row of rows) {
+  const detail = row.flagged.length ? `  ${row.flagged.join("  ")}` : "";
+  console.log(`${row.pkg.padEnd(22)} ${String(row.classes).padStart(2)} bindable class(es)${detail}`);
+}
+
+if (importFailures.length) {
+  console.log("\n--- Import failures (bundle could not be evaluated — fix the shim or the bundle) ---");
+  for (const failure of importFailures) console.log(`  ✗ ${failure.pkg}: ${failure.message}`);
+}
+
+if (violations.length) {
+  console.log("\n--- Violations ---");
+  for (const violation of violations) {
+    console.log(`  ✗ ${violation.key} — settable (prototype setter) but declared only in properties;`);
+    console.log(`     state→element writes are permanently suppressed under directional initial sync.`);
+    console.log(`     Fix: declare { name: "${violation.name}" } in inputs, or allowlist with a documented reason.`);
+  }
+}
+
+if (deviations.length) {
+  console.log("\n--- Documented deviations (◇) ---");
+  for (const deviation of deviations) console.log(`  ◇ ${deviation.key} — ${deviation.reason}`);
+}
+
+console.log("\n" + "-".repeat(72));
+console.log(`Packages: ${packages.length}  |  Classes: ${classesChecked}  |  properties-only members checked: ${membersChecked}  |  violations: ${violations.length}  |  deviations: ${deviations.length}  |  import failures: ${importFailures.length}`);
+if (violations.length > 0 || importFailures.length > 0) process.exitCode = 1;


### PR DESCRIPTION
Add scripts/conformance-bindable-inputs.mjs — a runtime conformance check for the invariant "a settable wcBindable member MUST also be declared in inputs" (state README "Binding Authority"). A settable member declared only in properties is output-only under directional initial sync: state→element writes are permanently suppressed. This drift shipped twice (router navigateUrl in v1.21.0, DCC $bindables after it) because both surfaces escape grep-based source sweeps.

Unlike the existing source lint, this check imports each package's dist bundle under a minimal DOM shim and inspects the evaluated declaration against prototype-chain setters, so dynamically generated declarations are covered. Current tree: 41 packages / 79 bindable classes / 441 properties-only members, 0 violations. Sensitivity was proven against the v1.20.0 router bundle, where the script flags navigateUrl.

Intentional output-only members with setters are recorded in an in-script allowlist with documented reasons (Router.path, StorageCore.value). Declaration factories that never surface through dist exports (DCC createWcBindable) stay locked by state's unit tests instead.

Wiring: new independent CI job bindable-conformance (committed dist), and a re-run in release.yml after the version-bump rebuild so freshly built bundles are gated before npm publish.