### PR TITLE
docs(vscode-wcs): fix wcs-validate invocation — the CLI is not on npm

### DIFF
--- a/packages/vscode-wcs/README.ja.md
+++ b/packages/vscode-wcs/README.ja.md
@@ -144,11 +144,21 @@ drift。診断には安定コード（例 `manifest-schema-version` / `manifest-
 
 単一の `validateDocument` 入口が IDE 診断と CLI の両方を駆動するため、エディタと CI で
 結果が一致します。同梱の **`wcs-validate`** CLI は同じ検査を—— `wcstack.manifest.json`
-sidecar および／または HTML の `data-wcs` バインディングに対して——ヘッドレスに CI 実行します:
+sidecar および／または HTML の `data-wcs` バインディングに対して——ヘッドレスに CI 実行します。
+本パッケージの配布先は VS Code Marketplace であり npm には公開していないため、
+`npx wcs-validate` は動きません。リポジトリからビルドして `node` で起動してください
+（このリポジトリ自身の `wcs-validate` CI job もまったく同じ起動方法です）:
 
 ```bash
-npx wcs-validate [--attr=data-wcs] [--state-tag=wcs-state] <file> [<file> ...]
+# 初回のみビルド（リポジトリルートから）
+cd packages/vscode-wcs && npm ci && npm run build && cd ../..
+
+node packages/vscode-wcs/dist/cli.cjs [--attr=data-wcs] [--state-tag=wcs-state] [--errors-only] <file> [<file> ...]
 ```
+
+`--errors-only`（別名 `--quiet`）は表示を error severity の行だけに絞ります。warning/info の
+件数集計と exit code は変わりません。exit code は error が 1 件でもあれば `1`、引数不正・
+ファイル読み取り失敗は `2`、それ以外は `0` です。
 
 sidecar は**ツール専用**です: 稼働中の `static wcBindable` 宣言を上書きすることはなく、
 ファイルの欠落や陳腐化がランタイム挙動を変えることもありません。規範的なスキーマと解決

--- a/packages/vscode-wcs/README.md
+++ b/packages/vscode-wcs/README.md
@@ -146,11 +146,20 @@ codes (e.g. `manifest-schema-version`, `manifest-kind-invalid`).
 A single `validateDocument` entry point drives both the in-editor diagnostics and
 the CLI, so the IDE and CI report identically. The bundled **`wcs-validate`** CLI
 runs the same checks headlessly — over `wcstack.manifest.json` sidecars and/or HTML
-`data-wcs` bindings — for CI:
+`data-wcs` bindings — for CI. This package ships to the VS Code Marketplace, not
+npm, so `npx wcs-validate` does not work; build it from this repo and invoke the
+CLI with `node` (this is exactly how the repo's own `wcs-validate` CI job runs it):
 
 ```bash
-npx wcs-validate [--attr=data-wcs] [--state-tag=wcs-state] <file> [<file> ...]
+# one-time build (from the repo root)
+cd packages/vscode-wcs && npm ci && npm run build && cd ../..
+
+node packages/vscode-wcs/dist/cli.cjs [--attr=data-wcs] [--state-tag=wcs-state] [--errors-only] <file> [<file> ...]
 ```
+
+`--errors-only` (alias `--quiet`) prints only error-severity lines; warning/info
+counts and the exit code are unchanged. The exit code is `1` when any error is
+reported, `2` on usage or file-read failure, `0` otherwise.
 
 The sidecar is **tooling-only**: it never overrides the runtime `static wcBindable`
 declaration, and a missing or stale file never changes runtime behavior. The


### PR DESCRIPTION
The README showed `npx wcs-validate ...`, but this package ships to the VS Code Marketplace only (release.yml publishes @wcstack/* scope), so npx cannot resolve it. Document the working invocation instead — build from the repo and run dist/cli.cjs with node, exactly as the repo's own wcs-validate CI job does — and document the --errors-only/--quiet flag and exit codes.