### PR TITLE
fix(state): dispatch mutations per-node instead of broadcasting to all sessions

### DIFF
--- a/e2e/bench/append-accumulation.mjs
+++ b/e2e/bench/append-accumulation.mjs
@@ -1,0 +1,121 @@
+// Append-accumulation probe for packages/state/__e2e__/benchmark/index.html.
+//
+// Regression driver for the BindingOwner mutation fanout: before the
+// node-interest registry, every appended row registered its own BindingSession
+// with the document owner, and every mutation batch was broadcast to ALL
+// sessions (cost = sessions x mutated nodes). Consecutive appends therefore
+// degraded quadratically (10k->11k slower than create 10k, 11k->12k ~2x that).
+// With per-node dispatch the series must stay flat.
+//
+// Usage (from e2e/):  node bench/append-accumulation.mjs --label after
+//
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const E2E_DIR = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const args = process.argv.slice(2);
+function argOf(name, dflt) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : dflt;
+}
+const PORT = Number(argOf("port", "4198"));
+const LABEL = argOf("label", "run");
+const APPENDS = Number(argOf("appends", "5"));
+const BENCH_URL = `http://127.0.0.1:${PORT}/packages/state/__e2e__/benchmark/index.html`;
+
+async function waitForServer(url, timeoutMs = 15000) {
+  const t0 = Date.now();
+  for (;;) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch { /* not up yet */ }
+    if (Date.now() - t0 > timeoutMs) throw new Error(`server not reachable: ${url}`);
+    await new Promise(r => setTimeout(r, 200));
+  }
+}
+
+// Same MutationObserver-clocked click timing as jsfb-verify.mjs.
+async function timedClick(page, clickSel, condSrc, condArg = null) {
+  return page.evaluate(
+    ({ clickSel, condSrc, condArg }) =>
+      new Promise((resolveP, rejectP) => {
+        const cond = new Function("arg", condSrc);
+        const target = document.querySelector("table.table") || document.body;
+        let t0;
+        const to = setTimeout(() => {
+          mo.disconnect();
+          rejectP(new Error(`timeout waiting condition after click ${clickSel}`));
+        }, 60000);
+        const check = () => {
+          if (cond(condArg)) {
+            clearTimeout(to);
+            mo.disconnect();
+            resolveP(performance.now() - t0);
+            return true;
+          }
+          return false;
+        };
+        const mo = new MutationObserver(check);
+        mo.observe(target, { childList: true, subtree: true, characterData: true, attributes: true });
+        t0 = performance.now();
+        document.querySelector(clickSel).click();
+        queueMicrotask(() => queueMicrotask(check));
+      }),
+    { clickSel, condSrc, condArg },
+  );
+}
+
+const COND_ROWCOUNT = `return document.querySelectorAll('tbody>tr').length === arg;`;
+
+// The mutation callback runs as a microtask after the click handler, but the
+// broadcast cost lands in the NEXT batch's delivery. Force the observer queue
+// to drain (one rAF + settle) so each sample charges its own delivery cost.
+async function settle(page) {
+  await page.evaluate(() => new Promise(r => requestAnimationFrame(() => setTimeout(r, 0))));
+}
+
+async function main() {
+  const server = spawn(process.execPath, ["serve.mjs"], {
+    cwd: E2E_DIR,
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: "ignore",
+  });
+  let browser;
+  try {
+    await waitForServer(BENCH_URL);
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    page.setDefaultTimeout(60000);
+    await page.goto(BENCH_URL, { waitUntil: "networkidle" });
+
+    const create10k = await timedClick(page, "#runlots", COND_ROWCOUNT, 10000);
+    await settle(page);
+    console.log(`[${LABEL}] create10k      ${create10k.toFixed(1)}ms`);
+
+    const appends = [];
+    for (let i = 0; i < APPENDS; i++) {
+      const t = await timedClick(page, "#add", COND_ROWCOUNT, 11000 + i * 1000);
+      await settle(page);
+      appends.push(t);
+      console.log(`[${LABEL}] append ${10 + i}k->${11 + i}k  ${t.toFixed(1)}ms`);
+    }
+
+    const clear = await timedClick(page, "#clear", COND_ROWCOUNT, 0);
+    console.log(`[${LABEL}] clear          ${clear.toFixed(1)}ms`);
+
+    const first = appends[0];
+    const last = appends[appends.length - 1];
+    console.log(`[${LABEL}] append growth last/first = ${(last / first).toFixed(2)}x`);
+  } finally {
+    if (browser) await browser.close();
+    server.kill();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/state/__tests__/bindings.BindingSession.branches.test.ts
+++ b/packages/state/__tests__/bindings.BindingSession.branches.test.ts
@@ -234,12 +234,77 @@ describe("BindingSession defensive branches", () => {
       constructor(callback: (mutations: MutationRecord[]) => void) { deliver = callback; }
       observe(): void {}
     });
-    vi.stubGlobal("WeakRef", class {
-      deref(): undefined { return undefined; }
-    });
-    const deadRoot = document.createElement("div").attachShadow({ mode: "open" });
-    new BindingSession(deadRoot);
+    const emptyRoot = document.createElement("div").attachShadow({ mode: "open" });
+    new BindingSession(emptyRoot);
     deliver([{ removedNodes: [], addedNodes: [] } as any]);
+  });
+
+  it("owner が interested session のみへ per-node 配送すること（単一値→Set昇格を含む）", () => {
+    let deliver!: (mutations: MutationRecord[]) => void;
+    vi.stubGlobal("MutationObserver", class {
+      constructor(callback: (mutations: MutationRecord[]) => void) { deliver = callback; }
+      observe(): void {}
+    });
+    const shadow = document.createElement("div").attachShadow({ mode: "open" });
+    const anchor = document.createElement("input");
+    const bystander = document.createElement("input");
+    shadow.appendChild(anchor);
+    shadow.appendChild(bystander);
+
+    const first = createBinding(anchor);
+    const second = createBinding(anchor);
+    const third = createBinding(anchor);
+    const unrelated = createBinding(bystander);
+    const firstSession = new BindingSession(shadow);
+    const secondSession = new BindingSession();
+    const thirdSession = new BindingSession();
+    const unrelatedSession = new BindingSession();
+    firstSession.initialize([first], { registerAddress: false });
+    secondSession.initialize([second], { registerAddress: false });
+    thirdSession.initialize([third], { registerAddress: false });
+    unrelatedSession.initialize([unrelated], { registerAddress: false });
+
+    // interest の無い node（テキスト）を含むサブツリー削除でも安全に配送されること
+    const wrapper = document.createElement("div");
+    wrapper.appendChild(document.createTextNode("no interest"));
+    shadow.appendChild(wrapper);
+    shadow.removeChild(wrapper);
+    shadow.removeChild(anchor);
+    deliver([
+      { removedNodes: [wrapper, anchor], addedNodes: [] } as any,
+    ]);
+    expect(firstSession.getRecord(first)?.phase).toBe("disposed");
+    expect(secondSession.getRecord(second)?.phase).toBe("disposed");
+    expect(thirdSession.getRecord(third)?.phase).toBe("disposed");
+    expect(unrelatedSession.getRecord(unrelated)?.phase).toBe("active");
+
+    // 再接続: interested な node のみ restart され、applyOnReconnect 分が一括適用される
+    shadow.appendChild(anchor);
+    deliver([{ removedNodes: [], addedNodes: [anchor, bystander] } as any]);
+    expect(firstSession.getRecord(first)?.phase).toBe("active");
+    expect(secondSession.getRecord(second)?.phase).toBe("active");
+    expect(mocks.apply).toHaveBeenCalledWith(expect.arrayContaining([first, second, third]));
+
+    // root から外れたままの node の追加通知は無視される
+    shadow.removeChild(anchor);
+    firstSession.disposeBinding(first);
+    deliver([{ removedNodes: [], addedNodes: [anchor] } as any]);
+    expect(firstSession.getRecord(first)?.phase).toBe("disposed");
+  });
+
+  it("session 単体の handleMutations が削除・追加サブツリーを per-node 処理すること", () => {
+    const session = new BindingSession();
+    const binding = createBinding();
+    session.initialize([binding], { registerAddress: false });
+    // 追加通知でも root 外なら無視される
+    session.handleMutations({ contains: () => false } as any, [], [binding.node]);
+    expect(session.getRecord(binding)?.phase).toBe("active");
+    session.handleMutations({ contains: () => false } as any, [binding.node], []);
+    expect(session.getRecord(binding)?.phase).toBe("disposed");
+    // 再接続成功時は applyOnReconnect 分が一括適用される
+    session.handleMutations({ contains: () => true } as any, [], [binding.node]);
+    expect(session.getRecord(binding)?.phase).toBe("active");
+    expect(mocks.apply).toHaveBeenCalledWith([binding]);
   });
 
   it("reconnect failure、owner final-state branches、root session cache を処理すること", () => {

--- a/packages/state/src/bindings/BindingSession.ts
+++ b/packages/state/src/bindings/BindingSession.ts
@@ -74,6 +74,38 @@ let nextGeneration = 0;
 const recordByBinding = new WeakMap<IBindingInfo, IInternalBindingRecord>();
 const sessionByRoot = new WeakMap<Node, BindingSession>();
 
+// node → その node に関心を持つ session（anchor として binding を覚えている、
+// または定義待ちタスクを抱えている）。BindingOwner は mutation で増減した
+// サブツリーを1回だけ走査し、ここに登録された session だけへ per-node 配送する。
+// 全 session ブロードキャストだと、リスト行の逐次 append などで
+// 「session 数 × 変異ノード数」の O(n²) ファンアウトになるため、その正本台帳。
+// 大多数の node は関心 session が1つなので単一値で持ち、2つ目から Set に昇格する。
+const interestedSessionsByNode = new WeakMap<Node, BindingSession | Set<BindingSession>>();
+
+function addInterestedSession(node: Node, session: BindingSession): void {
+  const current = interestedSessionsByNode.get(node);
+  if (typeof current === "undefined") {
+    interestedSessionsByNode.set(node, session);
+    return;
+  }
+  if (current === session) return;
+  if (current instanceof Set) {
+    current.add(session);
+    return;
+  }
+  interestedSessionsByNode.set(node, new Set([current, session]));
+}
+
+function forEachInterestedSession(node: Node, callback: (session: BindingSession) => void): void {
+  const current = interestedSessionsByNode.get(node);
+  if (typeof current === "undefined") return;
+  if (current instanceof Set) {
+    for (const session of Array.from(current)) callback(session);
+    return;
+  }
+  callback(current);
+}
+
 function forEachInclusive(root: Node, callback: (node: Node) => void): void {
   callback(root);
   for (const child of Array.from(root.childNodes)) {
@@ -93,8 +125,6 @@ function observableRootFor(node: Node): IObservableRoot | null {
 }
 
 class BindingOwner {
-  private readonly sessionRefs = new Set<WeakRef<BindingSession>>();
-  private readonly knownSessions = new WeakSet<BindingSession>();
   private readonly observer: MutationObserver | null;
 
   constructor(readonly root: IObservableRoot) {
@@ -105,12 +135,6 @@ class BindingOwner {
     this.observer?.observe(root, { childList: true, subtree: true });
   }
 
-  add(session: BindingSession): void {
-    if (this.knownSessions.has(session)) return;
-    this.knownSessions.add(session);
-    this.sessionRefs.add(new WeakRef(session));
-  }
-
   private handleMutations(mutations: MutationRecord[]): void {
     const removed: Node[] = [];
     const added: Node[] = [];
@@ -118,14 +142,26 @@ class BindingOwner {
       removed.push(...Array.from(mutation.removedNodes));
       added.push(...Array.from(mutation.addedNodes));
     }
-    for (const ref of Array.from(this.sessionRefs)) {
-      const session = ref.deref();
-      if (typeof session === "undefined") {
-        this.sessionRefs.delete(ref);
-        continue;
-      }
-      session.handleMutations(this.root, removed, added);
+    // 走査は owner が1回だけ行い、関心 session が居る node だけを配送・contains
+    // 検査へ進める。contains は O(木の深さ) なので、関心の無い node で呼ばない。
+    const reconnected: IBindingInfo[] = [];
+    for (const subtree of removed) {
+      forEachInclusive(subtree, (node) => {
+        forEachInterestedSession(node, (session) => {
+          if (this.root.contains(node)) return;
+          session.handleRemovedNode(node);
+        });
+      });
     }
+    for (const subtree of added) {
+      forEachInclusive(subtree, (node) => {
+        forEachInterestedSession(node, (session) => {
+          if (!this.root.contains(node)) return;
+          session.handleAddedNode(node, reconnected);
+        });
+      });
+    }
+    if (reconnected.length > 0) applyChangeFromBindings(reconnected);
   }
 }
 
@@ -233,6 +269,7 @@ export class BindingSession {
       raiseError(`CustomElementRegistry is unavailable for <${tagName}>.`);
     }
     this.observe(node);
+    addInterestedSession(node, this);
     const task: IDeferredDefinition = { node, active: true, cancel: null };
     let tasks = this.deferredByNode.get(node);
     if (typeof tasks === "undefined") {
@@ -289,58 +326,71 @@ export class BindingSession {
   observe(node: Node): void {
     const root = observableRootFor(node);
     if (root === null) return;
-    getBindingOwner(root).add(this);
+    // owner（root ごとの MutationObserver）の存在だけ保証する。session の配送先
+    // 登録は node 単位（interestedSessionsByNode）で行い、owner は session を
+    // 直接は保持しない。
+    getBindingOwner(root);
   }
 
   handleMutations(root: IObservableRoot, removed: readonly Node[], added: readonly Node[]): void {
     for (const subtree of removed) {
       forEachInclusive(subtree, (node) => {
         if (root.contains(node)) return;
-        const known = this.knownBindingsByNode.get(node);
-        if (typeof known !== "undefined") {
-          for (const binding of known.values()) this.disposeBinding(binding);
-        }
-        const tasks = this.deferredByNode.get(node);
-        if (typeof tasks !== "undefined") {
-          for (const task of Array.from(tasks)) {
-            task.active = false;
-            task.cancel?.();
-            tasks.delete(task);
-            this.deferred.delete(task);
-          }
-        }
+        this.handleRemovedNode(node);
       });
     }
-
     const reconnected: IBindingInfo[] = [];
     for (const subtree of added) {
       forEachInclusive(subtree, (node) => {
         if (!root.contains(node)) return;
-        const known = this.knownBindingsByNode.get(node);
-        if (typeof known === "undefined") return;
-        for (const binding of known.values()) {
-          const record = recordByBinding.get(binding);
-          if (record?.phase === "active") {
-            this.settleConnectedSnapshot(record);
-            continue;
-          }
-          if (record?.phase !== "disposed") continue;
-          const options = this.optionsByBinding.get(binding);
-          if (typeof options === "undefined") continue;
-          try {
-            this.start(binding, options);
-            if (options.applyOnReconnect && this.shouldApplyState(binding)) reconnected.push(binding);
-          } catch {
-            // Mutation delivery cannot surface initialization errors to a caller.
-          }
-        }
+        this.handleAddedNode(node, reconnected);
       });
     }
     if (reconnected.length > 0) applyChangeFromBindings(reconnected);
   }
 
+  handleRemovedNode(node: Node): void {
+    const known = this.knownBindingsByNode.get(node);
+    if (typeof known !== "undefined") {
+      for (const binding of known.values()) this.disposeBinding(binding);
+    }
+    const tasks = this.deferredByNode.get(node);
+    if (typeof tasks !== "undefined") {
+      for (const task of Array.from(tasks)) {
+        task.active = false;
+        task.cancel?.();
+        tasks.delete(task);
+        this.deferred.delete(task);
+      }
+    }
+  }
+
+  handleAddedNode(node: Node, reconnected: IBindingInfo[]): void {
+    const known = this.knownBindingsByNode.get(node);
+    if (typeof known === "undefined") return;
+    for (const binding of known.values()) {
+      const record = recordByBinding.get(binding);
+      if (record?.phase === "active") {
+        this.settleConnectedSnapshot(record);
+        continue;
+      }
+      if (record?.phase !== "disposed") continue;
+      const options = this.optionsByBinding.get(binding);
+      if (typeof options === "undefined") continue;
+      try {
+        this.start(binding, options);
+        if (options.applyOnReconnect && this.shouldApplyState(binding)) reconnected.push(binding);
+      } catch {
+        // Mutation delivery cannot surface initialization errors to a caller.
+      }
+    }
+  }
+
   private remember(binding: IBindingInfo, options: IBindingOptions): IBindingInfo {
     const anchor = binding.replaceNode;
+    // detached fragment 上でも登録しておく（node 単位の台帳なので root 非依存）。
+    // fragment 一括マウントで後から接続された行にも mutation 配送が届くようにする。
+    addInterestedSession(anchor, this);
     let known = this.knownBindingsByNode.get(anchor);
     if (typeof known === "undefined") {
       known = new Map();


### PR DESCRIPTION
BindingOwner delivered every mutation batch to every registered BindingSession, and each session then walked the entire added/removed subtrees (forEachInclusive + root.contains per node). Because each list row mounted via the connected-DOM path (partial append) registers its own session, appending 1000 rows to a 10k list cost sessions x nodes: ~15M walk callbacks, and every further append grew linearly worse (measured 3.5s -> 6.7s -> 10.1s -> 13.3s -> 17.2s per append).

Replace the broadcast with a node -> interested-session registry (single value, promoted to Set on the second session): sessions register their binding anchors in remember() and deferred-definition nodes in deferUntilDefined(), and the owner walks each mutated subtree exactly once, dispatching only to sessions registered for that node. contains() now runs only for nodes that have an interested session. The owner no longer tracks sessions at all (WeakRef bookkeeping removed); observe() just guarantees the root observer exists.

Registration is root-independent, so rows mounted detached through the DocumentFragment fast path now receive the same disposal/reconnect lifecycle as individually mounted rows once they hit the document.

Appends stay flat after the fix: create10k 428ms, five consecutive 1k appends 48ms each (growth 0.95x), clear10k 239ms. Regression driver: e2e/bench/append-accumulation.mjs.