### PR TITLE
fix(examples): repair websocket-chat react tsconfig and stale shared CSS imports

### DIFF
--- a/examples/websocket-chat/react/src/style.css
+++ b/examples/websocket-chat/react/src/style.css
@@ -1,4 +1,4 @@
-@import "../../shared/websocket/style.css";
+@import "../../shared/style.css";
 
 :root {
   color-scheme: light;

--- a/examples/websocket-chat/react/src/vite-env.d.ts
+++ b/examples/websocket-chat/react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/websocket-chat/react/tsconfig.json
+++ b/examples/websocket-chat/react/tsconfig.json
@@ -1,7 +1,16 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noEmit": true
   },
   "include": ["src"]

--- a/examples/websocket-chat/vue/src/style.css
+++ b/examples/websocket-chat/vue/src/style.css
@@ -1,4 +1,4 @@
-@import "../../shared/websocket/style.css";
+@import "../../shared/style.css";
 
 :root {
   color-scheme: light;


### PR DESCRIPTION
- react/tsconfig.json extended ../../tsconfig.json, which does not exist (examples/ has no tsconfig), so the IDE reported TS5083 and type checking of the app was degraded. Replace it with the self-contained config used by the other vite examples (packages/fetch/examples/pagination/react).
- Add src/vite-env.d.ts (vite/client types) so the ./style.css side-effect import type-checks under current TypeScript (TS7 flags unresolvable side-effect imports); tsc --noEmit now passes clean.
- react and vue imported ../../shared/websocket/style.css, a path from before the demo reorganization (81224960); the file now lives at websocket-chat/shared/style.css, so vite build failed with ENOENT. Point both at ../../shared/style.css. Verified: react and vue npm run build both succeed.