### PR TITLE
perf(state): jsfb hot-path improvements (remove -61%, clear -45%, create -16%)

### DIFF
--- a/e2e/bench/jsfb-verify.mjs
+++ b/e2e/bench/jsfb-verify.mjs
@@ -26,7 +26,8 @@ function argOf(name, dflt) {
 const PORT = Number(argOf("port", "4199"));
 const LABEL = argOf("label", "run");
 const OUT = argOf("out", `bench-${LABEL}.json`);
-const BENCH_URL = `http://127.0.0.1:${PORT}/packages/state/__e2e__/benchmark/index.html`;
+const PAGE = argOf("page", "packages/state/__e2e__/benchmark/index.html");
+const BENCH_URL = `http://127.0.0.1:${PORT}/${PAGE}`;
 
 // --- official isKeyed.ts instrumentation, minimally adapted (no shadow DOM) ---
 const INIT_DETECTOR = `

--- a/e2e/bench/op-profile.mjs
+++ b/e2e/bench/op-profile.mjs
@@ -49,22 +49,88 @@ function aggregate(profile) {
   return { rows: [...byFn.entries()].sort((a, b) => b[1] - a[1]), totalMs: total / 1000 };
 }
 
+async function setup1k(page) {
+  await page.goto(BENCH_URL, { waitUntil: "networkidle" });
+  await page.click("#run");
+  await page.waitForFunction(() => document.querySelectorAll("tbody>tr").length === 1000, null, { timeout: 60000 });
+}
+async function setup10k(page) {
+  await page.goto(BENCH_URL, { waitUntil: "networkidle" });
+  await page.click("#runlots");
+  await page.waitForFunction(() => document.querySelectorAll("tbody>tr").length === 10000, null, { timeout: 60000 });
+}
+
 async function setupAndAct(page) {
+  if (OP === "create1k") {
+    await page.goto(BENCH_URL, { waitUntil: "networkidle" });
+    return { click: "#run", wait: () => document.querySelectorAll("tbody>tr").length === 1000 };
+  }
   if (OP === "create10k") {
     await page.goto(BENCH_URL, { waitUntil: "networkidle" });
     return { click: "#runlots", wait: () => document.querySelectorAll("tbody>tr").length === 10000 };
   }
   if (OP === "clear10k") {
-    await page.goto(BENCH_URL, { waitUntil: "networkidle" });
-    await page.click("#runlots");
-    await page.waitForFunction(() => document.querySelectorAll("tbody>tr").length === 10000, null, { timeout: 60000 });
+    await setup10k(page);
     return { click: "#clear", wait: () => document.querySelectorAll("tbody>tr").length === 0 };
   }
   if (OP === "append") {
-    await page.goto(BENCH_URL, { waitUntil: "networkidle" });
-    await page.click("#runlots");
-    await page.waitForFunction(() => document.querySelectorAll("tbody>tr").length === 10000, null, { timeout: 60000 });
+    await setup10k(page);
     return { click: "#add", wait: () => document.querySelectorAll("tbody>tr").length === 11000 };
+  }
+  if (OP === "replace1k") {
+    // 1k rows already shown; #run replaces them with 1k fresh rows
+    await setup1k(page);
+    const prevLast = await page.evaluate(
+      () => document.querySelectorAll("tbody>tr")[999].cells[0].textContent.trim(),
+    );
+    return {
+      click: "#run",
+      wait: (arg) => {
+        const rows = document.querySelectorAll("tbody>tr");
+        return rows.length === 1000 && rows[999].cells[0].textContent.trim() !== arg;
+      },
+      waitArg: prevLast,
+    };
+  }
+  if (OP === "update10k") {
+    await setup10k(page);
+    const prevLabel = await page.evaluate(
+      () => document.querySelectorAll("tbody>tr")[9990].cells[1].textContent.trim(),
+    );
+    return {
+      click: "#update",
+      wait: (arg) => document.querySelectorAll("tbody>tr")[9990].cells[1].textContent.trim() !== arg,
+      waitArg: prevLabel,
+    };
+  }
+  if (OP === "select1k") {
+    await setup1k(page);
+    return {
+      click: "tbody>tr:nth-of-type(5)>td:nth-of-type(2)>a",
+      wait: () => document.querySelector("tbody>tr:nth-of-type(5)").classList.contains("danger"),
+    };
+  }
+  if (OP === "remove1k") {
+    await setup1k(page);
+    return {
+      click: "tbody>tr:nth-of-type(2)>td:nth-of-type(3)>a",
+      wait: () => document.querySelectorAll("tbody>tr").length === 999,
+    };
+  }
+  if (OP === "swap1k") {
+    await setup1k(page);
+    const expected = await page.evaluate(() => {
+      const rows = document.querySelectorAll("tbody>tr");
+      return { row2: rows[998].cells[0].textContent.trim(), row999: rows[1].cells[0].textContent.trim() };
+    });
+    return {
+      click: "#swaprows",
+      wait: (arg) => {
+        const rows = document.querySelectorAll("tbody>tr");
+        return rows[1].cells[0].textContent.trim() === arg.row2 && rows[998].cells[0].textContent.trim() === arg.row999;
+      },
+      waitArg: expected,
+    };
   }
   throw new Error(`unknown op ${OP}`);
 }
@@ -80,14 +146,14 @@ async function main() {
     const cdp = await page.context().newCDPSession(page);
     if (THROTTLE > 1) await cdp.send("Emulation.setCPUThrottlingRate", { rate: THROTTLE });
 
-    const { click, wait } = await setupAndAct(page);
+    const { click, wait, waitArg = null } = await setupAndAct(page);
 
     await cdp.send("Profiler.enable");
     await cdp.send("Profiler.setSamplingInterval", { interval: 100 });
     await cdp.send("Profiler.start");
     const t0 = await page.evaluate(() => performance.now());
     await page.click(click);
-    await page.waitForFunction(wait, null, { timeout: 60000 });
+    await page.waitForFunction(wait, waitArg, { timeout: 60000 });
     const t1 = await page.evaluate(() => performance.now());
     const { profile } = await cdp.send("Profiler.stop");
 

--- a/packages/signals/__e2e__/benchmark/index.html
+++ b/packages/signals/__e2e__/benchmark/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@wcstack/signals-"keyed"</title>
+    <link href="/packages/state/__e2e__/benchmark/css/currentStyle.css" rel="stylesheet"/>
+  </head>
+  <body>
+    <div class="container">
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-md-6">
+            <h1>@wcstack/signals-"keyed"</h1>
+          </div>
+          <div class="col-md-6">
+            <div class="row">
+              <div class="col-sm-6 smallpad">
+                <button class="btn btn-primary btn-block" id="run">Create 1,000 rows</button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button class="btn btn-primary btn-block" id="runlots">Create 10,000 rows</button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button class="btn btn-primary btn-block" id="add">Append 1,000 rows</button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button class="btn btn-primary btn-block" id="update">Update every 10th row</button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button class="btn btn-primary btn-block" id="clear">Clear</button>
+              </div>
+              <div class="col-sm-6 smallpad">
+                <button class="btn btn-primary btn-block" id="swaprows">Swap Rows</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="table table-hover table-striped test-data">
+        <tbody></tbody>
+      </table>
+    </div>
+    <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>
+
+    <script type="module">
+      import { signal, For, h, render, createRoot } from "/packages/signals/dist/dom.esm.js";
+      import { buildData } from "/packages/state/__e2e__/benchmark/buildData.js";
+
+      // Idiomatic fine-grained jsfb implementation (Solid-style): the list is a
+      // signal of row objects; each row's label is its own signal so "update
+      // every 10th row" touches only those rows' text bindings.
+      const data = signal([]);
+      const selected = signal(null);
+
+      const wrap = (items) => items.map((d) => ({ id: d.id, label: signal(d.label) }));
+
+      const actions = {
+        run() { data.set(wrap(buildData(1000))); selected.set(null); },
+        runlots() { data.set(wrap(buildData(10000))); selected.set(null); },
+        add() { data.set(data.peek().concat(wrap(buildData(1000)))); },
+        update() {
+          const d = data.peek();
+          for (let i = 0; i < d.length; i += 10) {
+            d[i].label.set(d[i].label.peek() + " !!!");
+          }
+        },
+        clear() { data.set([]); selected.set(null); },
+        swaprows() {
+          const d = data.peek();
+          if (d.length > 998) {
+            const next = d.slice();
+            [next[1], next[998]] = [next[998], next[1]];
+            data.set(next);
+          }
+        },
+      };
+      for (const id of Object.keys(actions)) {
+        document.getElementById(id).addEventListener("click", actions[id]);
+      }
+
+      const row = (item) =>
+        h("tr", { class: () => (selected.get() === item.id ? "danger" : "") },
+          h("td", { class: "col-md-1" }, String(item.id)),
+          h("td", { class: "col-md-4" },
+            h("a", { onClick: () => selected.set(item.id) }, () => item.label.get()),
+          ),
+          h("td", { class: "col-md-1" },
+            h("a", { onClick: () => data.set(data.peek().filter((r) => r.id !== item.id)) },
+              h("span", { class: "glyphicon glyphicon-remove", "aria-hidden": "true" }),
+            ),
+          ),
+          h("td", { class: "col-md-6" }),
+        );
+
+      const tbody = document.querySelector("tbody");
+      createRoot(() => {
+        render(For(data, row, { key: (r) => r.id }), tbody);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/state/__tests__/applyChangeToFor.poolCap.test.ts
+++ b/packages/state/__tests__/applyChangeToFor.poolCap.test.ts
@@ -206,6 +206,23 @@ describe('applyChangeToFor のプール上限', () => {
     expect(after.some(span => originalSpans.has(span))).toBe(false);
   });
 
+  it('一括削除パスが使えない場合でも wholesale 破棄はノードを個別に取り外すこと', () => {
+    restoreCap = __test_setMaxPooledContents(0);
+    const list = ['a', 'b', 'c'];
+    const { container, bindingInfo, placeholder } = mount(list);
+    // リスト領域の後ろに別要素を置き、textContent='' の一括破棄パスを不成立にする
+    const keeper = document.createElement('b');
+    keeper.textContent = 'keep';
+    container.appendChild(keeper);
+    expect(container.querySelectorAll('span')).toHaveLength(3);
+
+    apply(bindingInfo, []);
+    // 行は個別 removeChild で取り外され、リスト外の要素は残る
+    expect(container.querySelectorAll('span')).toHaveLength(0);
+    expect(container.contains(keeper)).toBe(true);
+    expect(getContentSetByNode(placeholder).size).toBe(0);
+  });
+
   it('既定の上限内では従来通り全件プール・再利用されること', () => {
     const list = ['a', 'b', 'c'];
     const { container, bindingInfo, placeholder } = mount(list);

--- a/packages/state/__tests__/bindings.collectNodesAndBindingInfos.test.ts
+++ b/packages/state/__tests__/bindings.collectNodesAndBindingInfos.test.ts
@@ -43,15 +43,19 @@ describe('collectNodesAndBindingInfos', () => {
     fragment.appendChild(comment);
 
     const nodeInfos = getFragmentNodeInfos(fragment);
+    // 事前正規化: text 専用コメントはテンプレート側で空 Text に置き換わる
+    expect(fragment.lastChild?.nodeType).toBe(Node.TEXT_NODE);
     const [nodes, bindings] = collectNodesAndBindingInfosByFragment(fragment, nodeInfos);
     expect(nodes).toHaveLength(2);
     expect(bindings).toHaveLength(2);
+    // 正規化済み Text は node がそのまま replaceNode になる
+    expect(bindings[1].node).toBe(bindings[1].replaceNode);
 
     const [, bindings2] = collectNodesAndBindingInfosByFragment(fragment, nodeInfos);
     expect(bindings2).toHaveLength(0);
 
-    unregisterNode(boundEl);
-    unregisterNode(comment);
+    unregisterNode(nodes[0]);
+    unregisterNode(nodes[1]);
     const [, bindings3] = collectNodesAndBindingInfosByFragment(fragment, nodeInfos);
     expect(bindings3).toHaveLength(2);
   });

--- a/packages/state/__tests__/bindings.initialSync.unit.test.ts
+++ b/packages/state/__tests__/bindings.initialSync.unit.test.ts
@@ -116,6 +116,12 @@ describe("initialSync policy resolution", () => {
       propName: "onclick",
       propModifiers: ["init=element"],
     }))).toThrow(/Event bindings only allow init=none/);
+    // sync=connect 併用時は凍結シングルトンではなく個別 policy を返す
+    expect(resolveInitialSyncPolicy(createBinding(node, {
+      bindingType: "event",
+      propName: "onclick",
+      propModifiers: ["sync=connect"],
+    }))).toEqual({ authority: "none", syncOn: "connect", observable: false });
   });
 
   it("prop 以外の binding type は state / none だけを許可すること", () => {

--- a/packages/state/__tests__/bindings.observerSkipOnAdd.test.ts
+++ b/packages/state/__tests__/bindings.observerSkipOnAdd.test.ts
@@ -1,0 +1,192 @@
+/**
+ * bindings.observerSkipOnAdd.test.ts — framework マウント由来の追加サブツリーに
+ * 対する MutationObserver 走査スキップ（削除側 observerSkip の対称形）の契約。
+ *
+ * - framework がマーク済みの追加サブツリーは、connect-snapshot 待ち
+ *   （observationPending な record）がグローバルにゼロなら走査されない
+ * - 待ちが 1 件でもあればマーク済みでも従来どおり走査され、接続時 snapshot が届く
+ * - 待ちカウンタは snapshot 消化・record 終端（dispose）で必ず戻る
+ * - マークは one-shot（1 回の配送で消費される）
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IBindingInfo } from "../src/types";
+
+const mocks = vi.hoisted(() => ({
+  state: {} as Record<PropertyKey, any>,
+  addAddress: vi.fn(),
+  removeAddress: vi.fn(),
+  clearAbsolute: vi.fn(),
+  clearStateAddress: vi.fn(),
+  setPathInfo: vi.fn(),
+  apply: vi.fn(),
+}));
+
+vi.mock("../src/apply/applyChangeFromBindings", () => ({
+  applyChangeFromBindings: mocks.apply,
+}));
+vi.mock("../src/binding/getAbsoluteStateAddressByBinding", () => ({
+  getAbsoluteStateAddressByBinding: vi.fn((binding: IBindingInfo) => ({ path: binding.statePathName })),
+  clearAbsoluteStateAddressByBinding: mocks.clearAbsolute,
+}));
+vi.mock("../src/binding/getBindingSetByAbsoluteStateAddress", () => ({
+  addBindingByAbsoluteStateAddress: mocks.addAddress,
+  removeBindingByAbsoluteStateAddress: mocks.removeAddress,
+}));
+vi.mock("../src/binding/getStateAddressByBindingInfo", () => ({
+  getStateAddressByBindingInfo: vi.fn((binding: IBindingInfo) => ({
+    pathInfo: {
+      path: binding.statePathName,
+      lastSegment: binding.statePathName,
+      wildcardCount: 0,
+    },
+    listIndex: null,
+    parentAddress: null,
+  })),
+  clearStateAddressByBindingInfo: mocks.clearStateAddress,
+}));
+vi.mock("../src/stateElementByName", () => ({
+  getStateElementByName: vi.fn(() => ({
+    setPathInfo: mocks.setPathInfo,
+    createState: (_mutability: string, callback: (state: any) => void) => callback(mocks.state),
+  })),
+}));
+
+import { BindingSession } from "../src/bindings/BindingSession";
+import {
+  consumeObserverSkipOnAdd,
+  hasPendingObservation,
+  markObserverSkipOnAdd,
+} from "../src/bindings/observerSkip";
+import { setConfig } from "../src/config";
+import { hasByAddressSymbol, setLoopContextSymbol } from "../src/proxy/symbols";
+
+let sequence = 0;
+const sessions: BindingSession[] = [];
+
+function nextTag(label: string): string {
+  sequence += 1;
+  return `x-obsskip-${label}-${sequence}`;
+}
+
+function declaration(properties: readonly any[]): any {
+  return { protocol: "wc-bindable", version: 1, properties };
+}
+
+function createBinding(node: Element, statePathName: string, modifiers: string[] = []): IBindingInfo {
+  return {
+    propName: "value",
+    propSegments: ["value"],
+    propModifiers: modifiers,
+    statePathName,
+    statePathInfo: { path: statePathName, wildcardCount: 0 } as any,
+    stateName: "default",
+    inFilters: [],
+    outFilters: [],
+    node,
+    replaceNode: node,
+    bindingType: "prop",
+  };
+}
+
+function session(root: Node = document): BindingSession {
+  const result = new BindingSession(root);
+  sessions.push(result);
+  return result;
+}
+
+async function flushMutations(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("追加側 observer スキップ（framework マウント）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.replaceChildren();
+    mocks.state = {
+      [setLoopContextSymbol]: (_context: unknown, callback: () => unknown) => callback(),
+      [hasByAddressSymbol]: (address: any) => address.pathInfo.path in mocks.state,
+    };
+    setConfig({ enableDirectionalInitialSync: true });
+  });
+
+  afterEach(async () => {
+    for (const current of sessions.splice(0)) current.dispose();
+    setConfig({ enableDirectionalInitialSync: false });
+    document.body.replaceChildren();
+    await flushMutations();
+  });
+
+  it("マーク済みの追加サブツリーは走査されず、マーク無しなら従来どおり restart すること", async () => {
+    const node = document.createElement("input");
+    const binding = createBinding(node, "plainValue");
+    const owner = session(document);
+    owner.initialize([binding]);
+    owner.disposeBinding(binding);
+    expect(owner.getRecord(binding)?.phase).toBe("disposed");
+
+    // framework マウント相当: マークして接続 → 追加走査がスキップされ restart しない
+    markObserverSkipOnAdd(node);
+    document.body.append(node);
+    await flushMutations();
+    expect(owner.getRecord(binding)?.phase).toBe("disposed");
+
+    // マークは消費済み（one-shot）なので、外部 DOM 操作の再接続は従来どおり届く
+    node.remove();
+    await flushMutations();
+    document.body.append(node);
+    await flushMutations();
+    expect(owner.getRecord(binding)?.phase).toBe("active");
+  });
+
+  it("connect-snapshot 待ちがある間はマーク済みでも走査され、snapshot が届くこと", async () => {
+    const tag = nextTag("connect");
+    customElements.define(tag, class extends HTMLElement {
+      static wcBindable = declaration([
+        { name: "value", event: "value-change", getter: (event: Event) => (event as CustomEvent).detail },
+      ]);
+      value: unknown = "before-connect";
+    });
+    const node = document.createElement(tag) as HTMLElement & { value: unknown };
+    const binding = createBinding(node, "connectedValue", ["sync=connect"]);
+    session(document).initialize([binding]);
+    // 未接続の two-way sync=connect → connect-snapshot 待ちが立つ
+    expect(hasPendingObservation()).toBe(true);
+
+    node.value = "connected-snapshot";
+    // framework マウント相当のマークがあっても、待ちがある間は走査に倒れる
+    markObserverSkipOnAdd(node);
+    document.body.append(node);
+    await flushMutations();
+
+    expect(mocks.state.connectedValue).toBe("connected-snapshot");
+    // snapshot 消化で待ちが戻り、以後のマークは再びスキップに使える
+    expect(hasPendingObservation()).toBe(false);
+  });
+
+  it("未消化の connect-snapshot 待ちは record 終端（dispose）で必ず戻ること", () => {
+    const tag = nextTag("dispose");
+    customElements.define(tag, class extends HTMLElement {
+      static wcBindable = declaration([
+        { name: "value", event: "value-change", getter: (event: Event) => (event as CustomEvent).detail },
+      ]);
+      value: unknown = "never-connected";
+    });
+    const node = document.createElement(tag) as HTMLElement & { value: unknown };
+    const binding = createBinding(node, "neverConnected", ["sync=connect"]);
+    const owner = session(document);
+    owner.initialize([binding]);
+    expect(hasPendingObservation()).toBe(true);
+
+    owner.dispose();
+    expect(hasPendingObservation()).toBe(false);
+  });
+
+  it("マークは one-shot で消費されること（未マークは false）", () => {
+    const node = document.createElement("div");
+    expect(consumeObserverSkipOnAdd(node)).toBe(false);
+    markObserverSkipOnAdd(node);
+    expect(consumeObserverSkipOnAdd(node)).toBe(true);
+    expect(consumeObserverSkipOnAdd(node)).toBe(false);
+  });
+});

--- a/packages/state/__tests__/bindings.wholesaleDestroy.test.ts
+++ b/packages/state/__tests__/bindings.wholesaleDestroy.test.ts
@@ -111,6 +111,40 @@ describe("wholesale destroy（clear 高速破棄）", () => {
     expect(mocks.detachEvent).not.toHaveBeenCalled();
   });
 
+  it("activate: 初回活性化はアドレス登録と初期同期だけ行うこと", () => {
+    const session = new BindingSession();
+    const binding = createBinding();
+    session.initialize([binding], { registerAddress: false });
+    expect(session.getRecord(binding)?.phase).toBe("active");
+    expect(mocks.addAddress).not.toHaveBeenCalled();
+
+    session.activate([binding]);
+    expect(mocks.addAddress).toHaveBeenCalledTimes(1);
+    // 再活性化（アドレス登録済み）では二重登録しない
+    session.activate([binding]);
+    expect(mocks.addAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("activate: pool 再利用（disposed record）は start で再構築されること", () => {
+    const session = new BindingSession();
+    const binding = createBinding();
+    session.initialize([binding], { registerAddress: false });
+    session.disposeBinding(binding);
+    expect(session.getRecord(binding)?.phase).toBe("disposed");
+
+    session.activate([binding]);
+    expect(session.getRecord(binding)?.phase).toBe("active");
+    expect(mocks.addAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("activate: remember されていない binding は従来 initialize に倒れること", () => {
+    const session = new BindingSession();
+    const binding = createBinding();
+    session.activate([binding]);
+    expect(session.getRecord(binding)?.phase).toBe("active");
+    expect(mocks.addAddress).toHaveBeenCalledTimes(1);
+  });
+
   it("tryDestroy: session を持たない content は false を返し何も壊さないこと", () => {
     const span = document.createElement("span");
     document.body.appendChild(span);

--- a/packages/state/__tests__/bindings.wholesaleDestroy.test.ts
+++ b/packages/state/__tests__/bindings.wholesaleDestroy.test.ts
@@ -1,0 +1,122 @@
+/**
+ * bindings.wholesaleDestroy.test.ts — clear の全行破棄で teardown を GC に任せる
+ * wholesale destroy 経路（BindingSession.canWholesaleDestroy / destroyRecords、
+ * Content.tryDestroy）の契約。
+ *
+ * - 定義待ち（pendingDefinitions / deferred タスク）や connect-snapshot 待ち
+ *   （observationPending）が 1 つでもあれば wholesale は不許可（従来経路に倒す）
+ * - destroyRecords は teardown（listener 解除等）を実行せずに record を終端化する
+ * - session を持たない content（SSR ハイドレーション産）は tryDestroy が false
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IBindingInfo } from "../src/types";
+
+const mocks = vi.hoisted(() => ({
+  customTag: null as string | null,
+  registry: null as any,
+  apply: vi.fn(),
+  addAddress: vi.fn(),
+  removeAddress: vi.fn(),
+  clearAbsolute: vi.fn(),
+  clearState: vi.fn(),
+  getAddress: vi.fn(() => ({ path: "value" })),
+  stateElement: { setPathInfo: vi.fn() } as any,
+  attachEvent: vi.fn(() => false),
+  detachEvent: vi.fn(),
+}));
+
+vi.mock("../src/getCustomElement", () => ({ getCustomElement: vi.fn(() => mocks.customTag) }));
+vi.mock("../src/apply/applyChangeFromBindings", () => ({ applyChangeFromBindings: mocks.apply }));
+vi.mock("../src/binding/getAbsoluteStateAddressByBinding", () => ({
+  getAbsoluteStateAddressByBinding: mocks.getAddress,
+  clearAbsoluteStateAddressByBinding: mocks.clearAbsolute,
+}));
+vi.mock("../src/binding/getBindingSetByAbsoluteStateAddress", () => ({
+  addBindingByAbsoluteStateAddress: mocks.addAddress,
+  removeBindingByAbsoluteStateAddress: mocks.removeAddress,
+}));
+vi.mock("../src/binding/getStateAddressByBindingInfo", () => ({ clearStateAddressByBindingInfo: mocks.clearState }));
+vi.mock("../src/stateElementByName", () => ({ getStateElementByName: vi.fn(() => mocks.stateElement) }));
+vi.mock("../src/event/handler", () => ({ attachEventHandler: mocks.attachEvent, detachEventHandler: mocks.detachEvent }));
+
+import { BindingSession } from "../src/bindings/BindingSession";
+import { createContentFromNodes } from "../src/structural/createContent";
+
+function createBinding(node: Element = document.createElement("input"), overrides: Partial<IBindingInfo> = {}): IBindingInfo {
+  return {
+    propName: "value",
+    propSegments: ["value"],
+    propModifiers: [],
+    statePathName: "value",
+    statePathInfo: { path: "value", wildcardCount: 0 } as any,
+    stateName: "default",
+    inFilters: [],
+    outFilters: [],
+    node,
+    replaceNode: node,
+    bindingType: "prop",
+    ...overrides,
+  };
+}
+
+describe("wholesale destroy（clear 高速破棄）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.customTag = null;
+    mocks.attachEvent.mockReturnValue(false);
+  });
+
+  it("canWholesaleDestroy: 素の session は許可されること", () => {
+    const session = new BindingSession();
+    session.initialize([createBinding()], { registerAddress: false });
+    expect(session.canWholesaleDestroy()).toBe(true);
+  });
+
+  it("canWholesaleDestroy: 定義待ち record があれば不許可になること", () => {
+    const session = new BindingSession();
+    const binding = createBinding();
+    session.initialize([binding], { registerAddress: false });
+    session.getRecord(binding)!.pendingDefinitions = 1;
+    expect(session.canWholesaleDestroy()).toBe(false);
+  });
+
+  it("canWholesaleDestroy: connect-snapshot 待ち record があれば不許可になること", () => {
+    const session = new BindingSession();
+    const binding = createBinding();
+    session.initialize([binding], { registerAddress: false });
+    session.getRecord(binding)!.observationPending = true;
+    expect(session.canWholesaleDestroy()).toBe(false);
+  });
+
+  it("canWholesaleDestroy: deferred タスクがあれば不許可になること", () => {
+    const session = new BindingSession();
+    session.initialize([createBinding()], { registerAddress: false });
+    (session as any).deferred.add({ node: document.createElement("div"), active: true, cancel: null });
+    expect(session.canWholesaleDestroy()).toBe(false);
+  });
+
+  it("destroyRecords: teardown を実行せずに record を終端化すること", () => {
+    const session = new BindingSession();
+    mocks.attachEvent.mockReturnValueOnce(true);
+    const eventBinding = createBinding(undefined, { bindingType: "event" });
+    session.initialize([eventBinding], { registerAddress: false });
+    expect(session.getRecord(eventBinding)?.phase).toBe("active");
+
+    session.destroyRecords();
+    expect(session.getRecord(eventBinding)?.phase).toBe("disposed");
+    // teardown（detachEventHandler）は走らない — listener はノードごと GC に任せる
+    expect(mocks.detachEvent).not.toHaveBeenCalled();
+    // 終端化済みなので dispose しても二重解体にならない
+    session.dispose();
+    expect(mocks.detachEvent).not.toHaveBeenCalled();
+  });
+
+  it("tryDestroy: session を持たない content は false を返し何も壊さないこと", () => {
+    const span = document.createElement("span");
+    document.body.appendChild(span);
+    const content = createContentFromNodes([span]);
+    expect(content.tryDestroy()).toBe(false);
+    expect(span.parentNode).not.toBeNull();
+    span.remove();
+  });
+});

--- a/packages/state/__tests__/dependency.walkDependency.diffExpansion.test.ts
+++ b/packages/state/__tests__/dependency.walkDependency.diffExpansion.test.ts
@@ -23,11 +23,12 @@ function usersAbsAddress(stateElement: IStateElement) {
   return createAbsoluteStateAddress(absPathInfo, null);
 }
 
-function runWalk(
+function runWalkRaw(
   stateElement: IStateElement,
   oldList: unknown[] | null,
   newList: unknown[],
   options?: { listExpansion?: 'full' | 'diff' },
+  staticDeps?: Map<string, string[]>,
 ) {
   const stateProxy = createStateProxy({ users: newList });
   if (oldList !== null) {
@@ -35,11 +36,11 @@ function runWalk(
     createListDiff(null, [], oldList);
     setLastListValueByAbsoluteStateAddress(usersAbsAddress(stateElement), oldList);
   }
-  const result = walkDependency(
+  return walkDependency(
     'default',
     stateElement,
     createStateAddress(getPathInfo('users'), null),
-    new Map<string, string[]>([['users', ['users.*']]]),
+    staticDeps ?? new Map<string, string[]>([['users', ['users.*']]]),
     new Map<string, string[]>(),
     new Set<string>(['users']),
     stateProxy,
@@ -47,10 +48,22 @@ function runWalk(
     () => {},
     options,
   );
+}
+
+function indexesOf(result: ReturnType<typeof runWalkRaw>, path: string) {
   return result
-    .filter(a => a.pathInfo.path === 'users.*')
+    .filter(a => a.pathInfo.path === path)
     .map(a => a.listIndex?.index ?? null)
     .sort((a, b) => (a ?? -1) - (b ?? -1));
+}
+
+function runWalk(
+  stateElement: IStateElement,
+  oldList: unknown[] | null,
+  newList: unknown[],
+  options?: { listExpansion?: 'full' | 'diff' },
+) {
+  return indexesOf(runWalkRaw(stateElement, oldList, newList, options), 'users.*');
 }
 
 describe('walkDependency の diff-filter 展開', () => {
@@ -78,10 +91,53 @@ describe('walkDependency の diff-filter 展開', () => {
     expect(runWalk(stateElement, oldList, newList, { listExpansion: 'diff' })).toEqual([0]);
   });
 
-  it('diff: スワップでは位置が変わった行のみ展開すること', () => {
+  it('diff: スワップでは index 依存 getter が無ければ移動行を展開しないこと（値は不変）', () => {
     const oldList = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const newList = [oldList[2], oldList[1], oldList[0]];
-    expect(runWalk(stateElement, oldList, newList, { listExpansion: 'diff' })).toEqual([0, 2]);
+    expect(runWalk(stateElement, oldList, newList, { listExpansion: 'diff' })).toEqual([]);
+  });
+
+  it('diff: スワップでは index 依存 getter のパスだけを移動行分展開すること', () => {
+    const idxElement = {
+      name: 'default',
+      indexDependentGetterPaths: new Set(['users.*.sel']),
+    } as unknown as IStateElement;
+    const oldList = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const newList = [oldList[2], oldList[1], oldList[0]];
+    const result = runWalkRaw(idxElement, oldList, newList, { listExpansion: 'diff' },
+      new Map([['users', ['users.*']], ['users.*', ['users.*.sel', 'users.*.name']]]));
+    // 行アドレス（users.*）と index を読まない値パス（users.*.name）は展開されない
+    expect(indexesOf(result, 'users.*')).toEqual([]);
+    expect(indexesOf(result, 'users.*.name')).toEqual([]);
+    expect(indexesOf(result, 'users.*.sel')).toEqual([0, 2]);
+  });
+
+  it('diff: 追加と移動が混在する場合、追加行は全体・移動行は index 依存 getter のみ展開すること', () => {
+    const idxElement = {
+      name: 'default',
+      indexDependentGetterPaths: new Set(['users.*.sel']),
+    } as unknown as IStateElement;
+    const oldList = [{ id: 1 }, { id: 2 }];
+    // 先頭に新規行を挿入: 既存 2 行は位置 0→1 / 1→2 に移動
+    const newList = [{ id: 99 }, oldList[0], oldList[1]];
+    const result = runWalkRaw(idxElement, oldList, newList, { listExpansion: 'diff' },
+      new Map([['users', ['users.*']], ['users.*', ['users.*.sel', 'users.*.name']]]));
+    expect(indexesOf(result, 'users.*')).toEqual([0]);
+    // 追加行は行全体の walk で users.*.name / users.*.sel とも展開される
+    expect(indexesOf(result, 'users.*.name')).toEqual([0]);
+    expect(indexesOf(result, 'users.*.sel')).toEqual([0, 1, 2]);
+  });
+
+  it('diff: ネストしたワイルドカード配下に index 依存 getter がある場合は移動行を全体展開に倒すこと', () => {
+    const idxElement = {
+      name: 'default',
+      indexDependentGetterPaths: new Set(['users.*.tags.*.badge']),
+    } as unknown as IStateElement;
+    const oldList = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const newList = [oldList[2], oldList[1], oldList[0]];
+    const result = runWalkRaw(idxElement, oldList, newList, { listExpansion: 'diff' },
+      new Map([['users', ['users.*']], ['users.*', ['users.*.tags']], ['users.*.tags', ['users.*.tags.*']], ['users.*.tags.*', ['users.*.tags.*.badge']]]));
+    expect(indexesOf(result, 'users.*')).toEqual([0, 2]);
   });
 
   it('diff: 同一参照の再代入では全行展開へ倒すこと（in-place 変異リフレッシュイディオム）', () => {

--- a/packages/state/__tests__/integration.wholesaleDestroy.test.ts
+++ b/packages/state/__tests__/integration.wholesaleDestroy.test.ts
@@ -1,0 +1,131 @@
+/**
+ * integration.wholesaleDestroy.test.ts — clear（全行削除）でプール超過分の
+ * content が wholesale destroy（teardown 省略・GC 任せ）されるエンドツーエンド契約。
+ *
+ * - プール超過分を wholesale 破棄しても DOM・再描画・イベント配線が正しく保たれる
+ * - ネストしたリストを含む行も再帰的に破棄される
+ * - 定義待ち等で wholesale できない content は従来経路で解体される（フォールバック）
+ */
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { bootstrapState } from "../src/bootstrapState";
+import { State } from "../src/components/State";
+import { getStateElementByName } from "../src/stateElementByName";
+import { __test_setMaxPooledContents } from "../src/apply/applyChangeToFor";
+import { getBindingSessionByContent } from "../src/bindings/bindingSessionByContent";
+import { getContentSetByNode } from "../src/structural/contentsByNode";
+
+beforeAll(() => {
+  bootstrapState();
+});
+
+let seq = 0;
+let restoreCap: number | null = null;
+const flush = () => new Promise((r) => setTimeout(r));
+
+afterEach(() => {
+  if (restoreCap !== null) {
+    __test_setMaxPooledContents(restoreCap);
+    restoreCap = null;
+  }
+});
+
+async function mount(initial: any, innerHTML: string) {
+  const host = document.createElement(`wsd-host-${seq++}`);
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  shadowRoot.innerHTML = innerHTML + `<wcs-state></wcs-state>`;
+  document.body.appendChild(host);
+  const stateEl = shadowRoot.querySelector("wcs-state") as State;
+  stateEl.setInitialState(initial);
+  await stateEl.connectedCallbackPromise;
+  await State.getBindingsReady(shadowRoot);
+  const stateElement = getStateElementByName(shadowRoot, "default")!;
+  return { host, shadowRoot, stateElement };
+}
+
+describe("clear の wholesale destroy（統合）", () => {
+  it("プール超過分を wholesale 破棄しても clear → 再生成 → イベントが正しく動くこと", async () => {
+    restoreCap = __test_setMaxPooledContents(2);
+    let clicked: number[] = [];
+    const { host, shadowRoot, stateElement } = await mount(
+      {
+        items: [{ v: 1 }, { v: 2 }, { v: 3 }, { v: 4 }, { v: 5 }],
+        onPick(this: any, _e: Event, $1: number) { clicked.push($1); },
+      },
+      `<ul><template data-wcs="for: items"><li><a data-wcs="onclick: onPick">{{ .v }}</a></li></template></ul>`,
+    );
+    const texts = () => Array.from(shadowRoot.querySelectorAll("li")).map(li => li.textContent);
+    expect(texts()).toEqual(["1", "2", "3", "4", "5"]);
+
+    stateElement.createState("writable", (s: any) => { s.items = []; });
+    await flush();
+    expect(texts()).toEqual([]);
+
+    // 再生成: プール 2 件 + 新規 3 件。描画・イベント配線とも正しいこと
+    stateElement.createState("writable", (s: any) => {
+      s.items = [{ v: 10 }, { v: 20 }, { v: 30 }, { v: 40 }, { v: 50 }];
+    });
+    await flush();
+    expect(texts()).toEqual(["10", "20", "30", "40", "50"]);
+
+    clicked = [];
+    (shadowRoot.querySelectorAll("li a")[3] as HTMLElement).click();
+    await flush();
+    expect(clicked).toEqual([3]);
+    host.remove();
+  });
+
+  it("ネストしたリストを含む行も wholesale 破棄で正しくクリア・再生成できること", async () => {
+    restoreCap = __test_setMaxPooledContents(0);
+    const { host, shadowRoot, stateElement } = await mount(
+      {
+        groups: [
+          { name: "g1", members: [{ n: "a" }, { n: "b" }] },
+          { name: "g2", members: [{ n: "c" }] },
+        ],
+      },
+      `<div><template data-wcs="for: groups"><section><h2>{{ .name }}</h2><ul><template data-wcs="for: .members"><li>{{ .n }}</li></template></ul></section></template></div>`,
+    );
+    const names = () => Array.from(shadowRoot.querySelectorAll("h2")).map(el => el.textContent);
+    const members = () => Array.from(shadowRoot.querySelectorAll("li")).map(el => el.textContent);
+    expect(names()).toEqual(["g1", "g2"]);
+    expect(members()).toEqual(["a", "b", "c"]);
+
+    stateElement.createState("writable", (s: any) => { s.groups = []; });
+    await flush();
+    expect(names()).toEqual([]);
+    expect(members()).toEqual([]);
+
+    stateElement.createState("writable", (s: any) => {
+      s.groups = [{ name: "g3", members: [{ n: "x" }, { n: "y" }] }];
+    });
+    await flush();
+    expect(names()).toEqual(["g3"]);
+    expect(members()).toEqual(["x", "y"]);
+    host.remove();
+  });
+
+  it("wholesale できない content（deferred タスク持ち）は従来経路で解体されること", async () => {
+    restoreCap = __test_setMaxPooledContents(0);
+    const { host, shadowRoot, stateElement } = await mount(
+      { items: [{ v: 1 }, { v: 2 }] },
+      `<ul><template data-wcs="for: items"><li>{{ .v }}</li></template></ul>`,
+    );
+    expect(shadowRoot.querySelectorAll("li")).toHaveLength(2);
+
+    // 1 行分の session に擬似 deferred タスクを注入し、tryDestroy を不許可にする
+    const anchor = Array.from(shadowRoot.querySelector("ul")!.childNodes)
+      .find(n => n.nodeType === Node.COMMENT_NODE)!;
+    const contents = Array.from(getContentSetByNode(anchor));
+    expect(contents.length).toBeGreaterThan(0);
+    const session = getBindingSessionByContent(contents[0])!;
+    const task = { node: document.createElement("div"), active: true, cancel: null };
+    (session as any).deferred.add(task);
+
+    stateElement.createState("writable", (s: any) => { s.items = []; });
+    await flush();
+    expect(shadowRoot.querySelectorAll("li")).toHaveLength(0);
+    // フォールバック（unmount 経由の session.dispose）で deferred も掃除される
+    expect((session as any).deferred.size).toBe(0);
+    host.remove();
+  });
+});

--- a/packages/state/__tests__/integration.wholesaleDestroy.test.ts
+++ b/packages/state/__tests__/integration.wholesaleDestroy.test.ts
@@ -104,6 +104,32 @@ describe("clear の wholesale destroy（統合）", () => {
     host.remove();
   });
 
+  it("ネスト内側の content が wholesale できない場合は unmount にフォールバックすること", async () => {
+    restoreCap = __test_setMaxPooledContents(0);
+    const { host, shadowRoot, stateElement } = await mount(
+      { groups: [{ name: "g1", members: [{ n: "a" }] }] },
+      `<div><template data-wcs="for: groups"><section><h2>{{ .name }}</h2><ul><template data-wcs="for: .members"><li>{{ .n }}</li></template></ul></section></template></div>`,
+    );
+    expect(shadowRoot.querySelectorAll("li")).toHaveLength(1);
+
+    // 内側リストの行 content の session に擬似 deferred タスクを注入し、
+    // 外側 tryDestroy の再帰で内側だけ unmount フォールバックさせる
+    const innerAnchor = Array.from(shadowRoot.querySelector("ul")!.childNodes)
+      .find(n => n.nodeType === Node.COMMENT_NODE)!;
+    const innerContents = Array.from(getContentSetByNode(innerAnchor));
+    expect(innerContents.length).toBeGreaterThan(0);
+    const innerSession = getBindingSessionByContent(innerContents[0])!;
+    (innerSession as any).deferred.add({ node: document.createElement("div"), active: true, cancel: null });
+
+    stateElement.createState("writable", (s: any) => { s.groups = []; });
+    await flush();
+    expect(shadowRoot.querySelectorAll("section")).toHaveLength(0);
+    expect(shadowRoot.querySelectorAll("li")).toHaveLength(0);
+    // フォールバック（unmount の session.dispose）で deferred も掃除される
+    expect((innerSession as any).deferred.size).toBe(0);
+    host.remove();
+  });
+
   it("wholesale できない content（deferred タスク持ち）は従来経路で解体されること", async () => {
     restoreCap = __test_setMaxPooledContents(0);
     const { host, shadowRoot, stateElement } = await mount(

--- a/packages/state/__tests__/proxy.setByAddress.test.ts
+++ b/packages/state/__tests__/proxy.setByAddress.test.ts
@@ -484,4 +484,150 @@ describe('setByAddress', () => {
     // エラーにならずに完了する
     setByAddress(target, address, 42, target, handler as any);
   });
+
+  describe('fast path（親を持つ未宣言の葉パス）', () => {
+    it('関数を親とする葉パスへの書き込みは従来経路で設定されること', () => {
+      const fnParent: any = function () {};
+      const target = {};
+      const address = createStateAddress(getPathInfo('factory.mode'), null);
+      const stateElement = createStateElement();
+      const handler = createHandler(stateElement);
+      vi.mocked(getByAddress).mockReturnValue(fnParent);
+
+      const result = setByAddress(target, address, 'fast', target, handler as any);
+      expect(result).toBe(true);
+      expect(fnParent.mode).toBe('fast');
+      expect(mockEnqueueAbsoluteAddress).toHaveBeenCalled();
+    });
+
+    it('同値ガード有効時、同値なら親解決 1 回で early return すること', () => {
+      setConfig({ sameValueGuard: true });
+      try {
+        const parent = { label: 'same' };
+        const target = {};
+        const address = createStateAddress(getPathInfo('row.label'), null);
+        const stateElement = createStateElement();
+        const handler = createHandler(stateElement);
+        vi.mocked(getByAddress).mockReturnValue(parent);
+
+        expect(setByAddress(target, address, 'same', target, handler as any)).toBe(true);
+        expect(mockEnqueueAbsoluteAddress).not.toHaveBeenCalled();
+        // 値が異なれば書き込まれ enqueue される
+        expect(setByAddress(target, address, 'next', target, handler as any)).toBe(true);
+        expect(parent.label).toBe('next');
+        expect(mockEnqueueAbsoluteAddress).toHaveBeenCalled();
+      } finally {
+        setConfig({ sameValueGuard: false });
+      }
+    });
+
+    it('fast path でも devtools sink に write イベントが流れること', async () => {
+      const { setDevtoolsSink } = await import('../src/devtools/sink');
+      const sink = vi.fn();
+      setConfig({ sameValueGuard: true });
+      try {
+        setDevtoolsSink(sink);
+        const parent = { label: 'old' };
+        const target = {};
+        const address = createStateAddress(getPathInfo('row.label'), null);
+        const stateElement = createStateElement();
+        const handler = createHandler(stateElement);
+        vi.mocked(getByAddress).mockReturnValue(parent);
+
+        setByAddress(target, address, 'new', target, handler as any);
+        expect(sink).toHaveBeenCalledWith(expect.objectContaining({
+          type: 'state:write',
+          value: 'new',
+          oldValue: 'old',
+          hasOldValue: true,
+        }));
+      } finally {
+        setDevtoolsSink(null);
+        setConfig({ sameValueGuard: false });
+      }
+    });
+
+    it('fast path でも bindableEventMap の CustomEvent がディスパッチされること', () => {
+      const host = document.createElement('div');
+      const shadow = host.attachShadow({ mode: 'open' });
+      const received: CustomEvent[] = [];
+      host.addEventListener('cfg-theme-changed', (e) => received.push(e as CustomEvent));
+
+      const parent = { theme: 'light' };
+      const target = {};
+      const address = createStateAddress(getPathInfo('cfg.theme'), null);
+      const stateElement = createStateElement({
+        bindableEventMap: { 'cfg.theme': 'cfg-theme-changed' },
+      });
+      (stateElement as any).rootNode = shadow;
+      const handler = createHandler(stateElement);
+      vi.mocked(getByAddress).mockReturnValue(parent);
+
+      setByAddress(target, address, 'dark', target, handler as any);
+      expect(parent.theme).toBe('dark');
+      expect(received).toHaveLength(1);
+      expect(received[0].detail).toBe('dark');
+    });
+
+    it('fast path で rootNode が ShadowRoot でなければディスパッチされず完了すること', () => {
+      const parent = { theme: 'light' };
+      const target = {};
+      const address = createStateAddress(getPathInfo('cfg.theme'), null);
+      const stateElement = createStateElement({
+        bindableEventMap: { 'cfg.theme': 'cfg-theme-changed' },
+      });
+      (stateElement as any).rootNode = document;
+      const handler = createHandler(stateElement);
+      vi.mocked(getByAddress).mockReturnValue(parent);
+
+      expect(setByAddress(target, address, 'dark', target, handler as any)).toBe(true);
+      expect(parent.theme).toBe('dark');
+    });
+
+    it('enablePropagationContext 無効時は context なしで enqueue されること', () => {
+      setConfig({ enablePropagationContext: false });
+      try {
+        const parent = { label: 'x' };
+        const target = {};
+        const address = createStateAddress(getPathInfo('row.label'), null);
+        const stateElement = createStateElement();
+        const handler = createHandler(stateElement);
+        vi.mocked(getByAddress).mockReturnValue(parent);
+
+        setByAddress(target, address, 'y', target, handler as any);
+        expect(mockEnqueueAbsoluteAddress).toHaveBeenCalledWith(expect.anything(), null);
+      } finally {
+        setConfig({ enablePropagationContext: true });
+      }
+    });
+
+    it('関数親のワイルドカード書き込みで listIndex が無ければ従来経路で raiseError すること', () => {
+      const fnParent: any = function () {};
+      const target = {};
+      const address = createStateAddress(getPathInfo('items.*'), null);
+      const stateElement = createStateElement();
+      const handler = createHandler(stateElement);
+      vi.mocked(getByAddress).mockReturnValue(fnParent);
+
+      expect(() => setByAddress(target, address, 'v', target, handler as any)).toThrow(/listIndex/);
+      expect(mockEnqueueAbsoluteAddress).toHaveBeenCalled();
+    });
+
+    it('同値ガード有効時、listIndex の無いワイルドカードは has=false 扱いで raiseError まで進むこと', () => {
+      setConfig({ sameValueGuard: true });
+      try {
+        const parent: any[] = ['a'];
+        const target = {};
+        const address = createStateAddress(getPathInfo('items.*'), null);
+        const stateElement = createStateElement();
+        const handler = createHandler(stateElement);
+        vi.mocked(getByAddress).mockReturnValue(parent);
+
+        expect(() => setByAddress(target, address, 'b', target, handler as any)).toThrow(/listIndex/);
+        expect(mockEnqueueAbsoluteAddress).toHaveBeenCalled();
+      } finally {
+        setConfig({ sameValueGuard: false });
+      }
+    });
+  });
 });

--- a/packages/state/__tests__/structural.activateContent.test.ts
+++ b/packages/state/__tests__/structural.activateContent.test.ts
@@ -108,19 +108,15 @@ describe('activateContent', () => {
       const context = {} as any;
       const allowed = { id: 1 } as any;
       const denied = { id: 2 } as any;
-      const initialize = vi.fn(() => [allowed]);
+      const activate = vi.fn();
       const shouldApplyState = vi.fn((binding: any) => binding === allowed);
 
       getBindingsByContentMock.mockReturnValue([allowed, denied]);
-      setBindingSessionByContent(content, { initialize, shouldApplyState } as any);
+      setBindingSessionByContent(content, { activate, shouldApplyState } as any);
 
       activateContent(content, null, context);
 
-      expect(initialize).toHaveBeenCalledWith([allowed, denied], {
-        registerAddress: true,
-        registerPathInfo: false,
-        applyOnReconnect: false,
-      });
+      expect(activate).toHaveBeenCalledWith([allowed, denied]);
       expect(addBindingByAbsoluteStateAddressMock).not.toHaveBeenCalled();
       expect(applyChangeMock).toHaveBeenCalledTimes(1);
       expect(applyChangeMock).toHaveBeenCalledWith(allowed, context);

--- a/packages/state/__tests__/structural.collectStructuralFragments.test.ts
+++ b/packages/state/__tests__/structural.collectStructuralFragments.test.ts
@@ -443,9 +443,12 @@ describe('collectStructuralFragments', () => {
 
       const info = getFragmentInfoByUUID('uuid-collect-0');
       expect(info).not.toBeNull();
-      // コメントが展開されていること
-      const fragmentComment = info?.fragment.firstChild as Comment;
-      expect(fragmentComment.data).toBe('@@: users.*.name');
+      // ショートハンドが展開されて nodeInfos に記録され、コメント自体は
+      // 事前正規化で空 Text プレースホルダに置き換わっていること
+      expect(info?.fragment.firstChild?.nodeType).toBe(Node.TEXT_NODE);
+      expect(info?.nodeInfos).toHaveLength(1);
+      expect(info?.nodeInfos[0].parseBindTextResults[0].statePathName).toBe('users.*.name');
+      expect(info?.nodeInfos[0].parseBindTextResults[0].bindingType).toBe('text');
     });
 
     it('forテンプレート内の要素属性のショートハンドが展開されること', () => {

--- a/packages/state/src/address/ResolvedAddress.ts
+++ b/packages/state/src/address/ResolvedAddress.ts
@@ -37,7 +37,6 @@ const _cache: Map<string, IResolvedAddress> = new Map();
 class ResolvedAddress implements IResolvedAddress {
   readonly path;
   readonly segments;
-  readonly paths;
   readonly wildcardCount;
   readonly wildcardType;
   readonly wildcardIndexes;
@@ -55,14 +54,12 @@ class ResolvedAddress implements IResolvedAddress {
     // Split path into individual segments
     const segments = path.split(".");
     const tmpPatternSegments = segments.slice();
-    const paths = [];
     let incompleteCount = 0; // Count of unresolved wildcards (*)
     let completeCount = 0;   // Count of resolved wildcards (numeric indexes)
-    let lastPath = "";
     let wildcardCount = 0;
     let wildcardType: WildcardType = "none";
     const wildcardIndexes: (number | null)[] = [];
-    
+
     // Process each segment to identify wildcards and indexes
     for(let i = 0; i < segments.length; i++) {
       const segment = segments[i];
@@ -82,10 +79,6 @@ class ResolvedAddress implements IResolvedAddress {
           wildcardCount++;
         }
       }
-      // Build cumulative path array
-      lastPath += segment;
-      paths.push(lastPath);
-      lastPath += (i < segment.length - 1 ? "." : "");
     }
     // Generate pattern string with wildcards normalized
     const structuredPath = tmpPatternSegments.join(".");
@@ -106,7 +99,6 @@ class ResolvedAddress implements IResolvedAddress {
     }
     this.path = path;
     this.segments = segments;
-    this.paths = paths;
     this.wildcardCount = wildcardCount;
     this.wildcardType = wildcardType;
     this.wildcardIndexes = wildcardIndexes;

--- a/packages/state/src/address/types.ts
+++ b/packages/state/src/address/types.ts
@@ -51,7 +51,6 @@ export type WildcardType = "none" | "context" | "partial" | "all";
 export interface IResolvedAddress {
   readonly path: string;
   readonly segments: string[];
-  readonly paths: string[];
   readonly wildcardType: WildcardType;
   readonly wildcardIndexes: (number | null)[];
   

--- a/packages/state/src/apply/applyChange.ts
+++ b/packages/state/src/apply/applyChange.ts
@@ -43,6 +43,11 @@ const applyChangeByBindingType: { [key: string]: ApplyChangeFn } = {
 const fnByBinding: WeakMap<IBindingInfo, ApplyChangeFn> = new WeakMap();
 const deferredSelectBindingByBinding: WeakMap<IBindingInfo, boolean> = new WeakMap();
 
+// 未 define カスタム要素チェックの確定メモ。customTag が無い、または define 済みを
+// 一度確認したら以後は不変（define は不可逆）なので apply 毎の getCustomElement /
+// registry 照会を省略できる。scoped registry を導入する場合はこの不可逆前提を再検討。
+const definedApplyVerifiedByBinding: WeakMap<IBindingInfo, boolean> = new WeakMap();
+
 function _applyChange(binding: IBindingInfo, context: IApplyContext): void {
   const value = getValue(context.state, binding);
   const filteredValue = getFilteredValue(value, binding.outFilters);
@@ -127,16 +132,20 @@ export function applyChange(binding: IBindingInfo, context: IApplyContext): void
   if (binding.bindingType === "event") {
     return;
   }
-  const customTag = getCustomElement(binding.replaceNode);
-  if (customTag) {
-    if (getCustomElementRegistry()?.get(customTag) === undefined) {
-      // 未 define のカスタム要素へは今は適用できない（accessor 未確立の要素に
-      // 素の own property を書くと upgrade 後に class accessor を隠してしまう）。
-      // whenDefined 後に最新 state 値で再適用する（two-way attach / deferred
-      // spread と対称。docs/state-binding-init-races.md §2）。
-      scheduleDeferredApply(binding, customTag);
-      return;
+  if (definedApplyVerifiedByBinding.get(binding) !== true) {
+    const customTag = getCustomElement(binding.replaceNode);
+    if (customTag) {
+      if (getCustomElementRegistry()?.get(customTag) === undefined) {
+        // 未 define のカスタム要素へは今は適用できない（accessor 未確立の要素に
+        // 素の own property を書くと upgrade 後に class accessor を隠してしまう）。
+        // whenDefined 後に最新 state 値で再適用する（two-way attach / deferred
+        // spread と対称。docs/state-binding-init-races.md §2）。
+        scheduleDeferredApply(binding, customTag);
+        return;
+      }
     }
+    // customTag 無し or define 済み確定 → 以後この検査を省略（不可逆）
+    definedApplyVerifiedByBinding.set(binding, true);
   }
   // applyChangeFromBindings のグループ化ループが解決済みルートの一致を検証済みの
   // 場合、stateName さえ一致すれば getRootNode の再解決（native 呼び出し）を省略

--- a/packages/state/src/apply/applyChangeToFor.ts
+++ b/packages/state/src/apply/applyChangeToFor.ts
@@ -162,11 +162,10 @@ export function applyChangeToFor(
   const diff = createListDiff(listIndex, lastValue, newValue);
   context.newListValueByAbsAddress.set(absAddress, Array.isArray(newValue) ? newValue : []);
 
-  if (Array.isArray(lastValue) 
-    && lastValue.length === diff.deleteIndexSet.size 
-    && diff.deleteIndexSet.size > 0
-    && bindingInfo.node.parentNode !== null
-  ) {
+  const fullDelete = Array.isArray(lastValue)
+    && lastValue.length === diff.deleteIndexSet.size
+    && diff.deleteIndexSet.size > 0;
+  if (fullDelete && bindingInfo.node.parentNode !== null) {
     let isOnlyNode = isOnlyNodeInParentContentByNode.get(bindingInfo.node);
     if (typeof isOnlyNode === 'undefined') {
       const lastNode = lastNodeByNode.get(bindingInfo.node) || bindingInfo.node;
@@ -179,12 +178,24 @@ export function applyChangeToFor(
       parentNode.appendChild(bindingInfo.node);
     }
   }
+  // 全削除時、プールに収まらない content は再利用されないため、per-binding の
+  // teardown（listener 解除・アドレス台帳・loopContext 掃除）を丸ごと省略して
+  // ノードごと GC に任せる（tryDestroy）。プール行きの分だけ従来どおり解体する
+  // （プール行は binding が生存し続けるため address キャッシュのクリアが必須）。
+  let poolBudget = fullDelete
+    ? maxPooledContents - getPooledContents(bindingInfo).length
+    : Number.POSITIVE_INFINITY;
   for(const deleteIndex of diff.deleteIndexSet) {
     const content = getContent(bindingInfo.node, deleteIndex);
     if (content !== null) {
-      deactivateContent(content);
-      content.unmount();
-      setPooledContent(bindingInfo, content);
+      if (poolBudget <= 0 && content.tryDestroy()) {
+        deleteContentByNode(bindingInfo.node, content);
+      } else {
+        deactivateContent(content);
+        content.unmount();
+        setPooledContent(bindingInfo, content);
+        poolBudget -= 1;
+      }
       setContent(bindingInfo.node, deleteIndex, null);
     }
   }

--- a/packages/state/src/bindings/BindingSession.ts
+++ b/packages/state/src/bindings/BindingSession.ts
@@ -342,6 +342,35 @@ export class BindingSession {
     }
   }
 
+  /**
+   * wholesale destroy（全行クリアで teardown を GC に任せる高速経路）を適用して
+   * よいか。定義待ち（DefinitionCoordinator の waiter / deferred spread タスク）は
+   * 強参照 Map に閉包が残り、connect-snapshot 待ちは pending カウンタが戻らなく
+   * なるため、1 つでもあれば従来経路（teardown 実行）に倒す。
+   */
+  canWholesaleDestroy(): boolean {
+    if (this.deferred.size > 0) return false;
+    for (const record of this.records) {
+      if (record.pendingDefinitions > 0 || record.observationPending) return false;
+    }
+    return true;
+  }
+
+  /**
+   * 全 record を teardown を走らせずに終端化する（canWholesaleDestroy が true の
+   * content 専用）。イベント listener・アドレス台帳・loopContext はノード/binding
+   * もろとも GC で崩壊する（recordByBinding 以下は全て弱参照）。
+   * handlerBindingRegistry のカウンタは減らないが、残るのはキー文字列と数値のみで
+   * 実害はない設計（handlerBindingRegistry.ts の弱参照化コメント参照）。
+   */
+  destroyRecords(): void {
+    for (const record of this.records) {
+      record.phase = "disposed";
+      record.teardowns.clear();
+    }
+    this.records.clear();
+  }
+
   observe(node: Node): void {
     const root = observableRootFor(node);
     if (root === null) return;

--- a/packages/state/src/bindings/BindingSession.ts
+++ b/packages/state/src/bindings/BindingSession.ts
@@ -15,7 +15,7 @@ import { getCustomElementRegistry, upgradeCustomElement } from "../platform/cust
 import { raiseError } from "../raiseError";
 import { getStateElementByName } from "../stateElementByName";
 import { IBindingInfo } from "../types";
-import { consumeObserverSkipOnRemove } from "./observerSkip";
+import { consumeObserverSkipOnAdd, consumeObserverSkipOnRemove, decrementPendingObservation, hasPendingObservation, incrementPendingObservation } from "./observerSkip";
 import { DefinitionCoordinator, getDefinitionCoordinator } from "./DefinitionCoordinator";
 import { commitProducerValue, hasInitialSyncModifier, IInitialSyncPolicy, ResolvedInitialAuthority, resolveInitialAuthority, resolveInitialSyncPolicy } from "./initialSync";
 import { replaceToReplaceNode } from "./replaceToReplaceNode";
@@ -169,6 +169,10 @@ class BindingOwner {
       });
     }
     for (const subtree of added) {
+      // framework がマウントしたサブツリーは record が同期 activate 済みで、追加側
+      // 走査の実質の仕事は connect-snapshot 待ちへの配送だけ。待ちがグローバルに
+      // 無ければ丸ごとスキップする（待ちがあればマークだけ消費して従来走査に戻す）。
+      if (consumeObserverSkipOnAdd(subtree) && !hasPendingObservation()) continue;
       forEachInclusive(subtree, (node) => {
         forEachInterestedSession(node, (session) => {
           if (!this.root.contains(node)) return;
@@ -580,6 +584,8 @@ export class BindingSession {
         && !record.info.node.isConnected
       ) {
         record.observationPending = true;
+        // 待ちが 1 件でもある間は追加側 observer スキップを無効化する
+        incrementPendingObservation();
         return;
       }
       this.readProducerSnapshot(record, policy.syncOn === "call");
@@ -598,7 +604,10 @@ export class BindingSession {
     if (!(name in target)) return;
     const sequence = record.eventSequence;
     const value = target[name];
-    record.observationPending = false;
+    if (record.observationPending) {
+      record.observationPending = false;
+      decrementPendingObservation();
+    }
     if (eventWins && record.eventSequence !== sequence) return;
     record.hasProducerValue = true;
     record.producerValue = value;
@@ -662,6 +671,12 @@ export class BindingSession {
   }
 
   private runTeardowns(record: IInternalBindingRecord): void {
+    // runTeardowns は record の終端（disposed / failed）でのみ呼ばれる。未消化の
+    // connect-snapshot 待ちが残っていれば必ずカウンタを戻す（スキップ再有効化）。
+    if (record.observationPending) {
+      record.observationPending = false;
+      decrementPendingObservation();
+    }
     const teardowns = Array.from(record.teardowns).reverse();
     record.teardowns.clear();
     for (const teardown of teardowns) {

--- a/packages/state/src/bindings/BindingSession.ts
+++ b/packages/state/src/bindings/BindingSession.ts
@@ -251,6 +251,41 @@ export class BindingSession {
     return initialized.filter((binding) => this.shouldApplyState(binding));
   }
 
+  /**
+   * activateContent 専用の再活性化パス。createContent 側の initialize で
+   * remember 済みの binding 配列（bindingsByContent がそのまま保持する同一オブジェクト）
+   * にだけ使える前提で、remember の再実行（キー照合・options マージ・興味登録）を省き、
+   * 必要な仕事だけ行う: 初回活性化はアドレス登録+初期同期、pool 再利用（disposed）は
+   * start による再構築、未知の binding は防御的に従来 initialize へ倒す。
+   */
+  activate(bindings: readonly IBindingInfo[]): void {
+    for (const binding of bindings) {
+      const record = recordByBinding.get(binding);
+      if (typeof record !== "undefined" && record.session === this
+        && record.phase !== "disposed" && record.phase !== "failed") {
+        if (record.address === null) {
+          // 初回活性化（mountAfter 経路では anchor が接続済みのことがあるため、
+          // 従来 initialize と同様に owner の存在をここで保証する）
+          this.observe(record.anchor);
+          record.options.registerAddress = true;
+          this.registerAddress(record);
+        }
+        if (record.phase === "active") this.settleInitialRecord(record);
+        this.settleConnectedSnapshot(record);
+        continue;
+      }
+      const options = this.optionsByBinding.get(binding);
+      if (typeof options === "undefined") {
+        // この session で remember されていない binding（防御）: 従来経路
+        this.initialize([binding], { registerAddress: true, registerPathInfo: false, applyOnReconnect: false });
+        continue;
+      }
+      // pool 再利用: record は disposed。活性化要件（アドレス登録）を昇格して再構築
+      options.registerAddress = true;
+      this.start(binding, options);
+    }
+  }
+
   shouldApplyState(binding: IBindingInfo): boolean {
     if (!config.enableDirectionalInitialSync) {
       if (hasInitialSyncModifier(binding)) resolveInitialSyncPolicy(binding);

--- a/packages/state/src/bindings/getBindingInfos.ts
+++ b/packages/state/src/bindings/getBindingInfos.ts
@@ -11,7 +11,13 @@ export function getBindingInfos(node: Node, parseBindingTextResults: ParseBindTe
         replaceNode: node,
       });
     } else {
-      const replaceNode = document.createTextNode('');
+      // フラグメント登録時に事前正規化済みの Text ノードはそのまま replaceNode に
+      // 使う（node === replaceNode なら replaceToReplaceNode は no-op）。
+      // 実 DOM 上の wcs-text コメント（非フラグメント経路）は従来どおり
+      // 空 Text を生成して実行時に差し替える。
+      const replaceNode = node.nodeType === Node.TEXT_NODE
+        ? node
+        : document.createTextNode('');
       bindingInfos.push({
         ...parseBindingTextResult,
         node: node,

--- a/packages/state/src/bindings/initialSync.ts
+++ b/packages/state/src/bindings/initialSync.ts
@@ -57,12 +57,23 @@ export function hasInitialSyncModifier(binding: IBindingInfo): boolean {
   return binding.propModifiers.some((modifier) => modifier.includes("="));
 }
 
+// 頻出ポリシー（修飾子なしの通常バインディング）の凍結シングルトン。リスト行では
+// binding ごとに resolveInitialSyncPolicy が走るため、毎回のオブジェクト割り当てを
+// 避ける（record.initialPolicy は読み取り専用でしか使われない）。
+const STATE_CALL_POLICY: IInitialSyncPolicy = Object.freeze({ authority: "state", syncOn: "call", observable: false });
+const NONE_CALL_POLICY: IInitialSyncPolicy = Object.freeze({ authority: "none", syncOn: "call", observable: false });
+
+function statePolicy(authority: InitialAuthority, syncOn: IInitialSyncPolicy["syncOn"]): IInitialSyncPolicy {
+  if (authority === "state" && syncOn === "call") return STATE_CALL_POLICY;
+  return { authority, syncOn, observable: false };
+}
+
 export function resolveInitialSyncPolicy(binding: IBindingInfo): IInitialSyncPolicy {
   if (!config.enableDirectionalInitialSync) {
     if (hasInitialSyncModifier(binding)) {
       raiseError("init=/sync= modifiers require enableDirectionalInitialSync.");
     }
-    return { authority: "state", syncOn: "call", observable: false };
+    return STATE_CALL_POLICY;
   }
 
   const explicitAuthority = parseAuthority(readOption(binding, "init"));
@@ -71,7 +82,7 @@ export function resolveInitialSyncPolicy(binding: IBindingInfo): IInitialSyncPol
     if (explicitAuthority !== null && explicitAuthority !== "none") {
       raiseError("Event bindings only allow init=none.");
     }
-    return { authority: "none", syncOn, observable: false };
+    return syncOn === "call" ? NONE_CALL_POLICY : { authority: "none", syncOn, observable: false };
   }
   // command.<name>: $command.<method> は命令的な command-token 配線。bindingType は
   // "prop" だが propName ("command.<name>") は wcBindable property ではないため、下の
@@ -79,18 +90,18 @@ export function resolveInitialSyncPolicy(binding: IBindingInfo): IInitialSyncPol
   // 持たない配線なので、現行互換の "state" authority を返す(command token は従来通り
   // 初期 apply で配線される)。
   if (binding.propSegments[0] === "command") {
-    return { authority: "state", syncOn, observable: false };
+    return statePolicy("state", syncOn);
   }
   if (binding.bindingType !== "prop") {
     if (explicitAuthority !== null && explicitAuthority !== "state" && explicitAuthority !== "none") {
       raiseError(`Binding type "${binding.bindingType}" does not support init=${explicitAuthority}.`);
     }
-    return { authority: explicitAuthority ?? "state", syncOn, observable: false };
+    return statePolicy(explicitAuthority ?? "state", syncOn);
   }
 
   const declaration = readBindableDeclaration(binding.node);
   if (declaration === null) {
-    return { authority: explicitAuthority ?? "state", syncOn, observable: false };
+    return statePolicy(explicitAuthority ?? "state", syncOn);
   }
   const hasOutput = declaration.knownProperties.has(binding.propName);
   const hasInput = declaration.declaredInputs.has(binding.propName);

--- a/packages/state/src/bindings/initializeBindingPromiseByNode.ts
+++ b/packages/state/src/bindings/initializeBindingPromiseByNode.ts
@@ -1,6 +1,9 @@
 import { IInitializeBindingPromise } from "./types";
 
 const bindingPromiseByNode = new WeakMap<Node, IInitializeBindingPromise>();
+// resolve 済みマーク。エントリ未生成のまま resolve されたノードは、後から
+// wait された時に「生成して即 resolve」で追いつく。
+const resolvedNodes = new WeakSet<Node>();
 
 let id = 0;
 
@@ -19,6 +22,9 @@ export function getInitializeBindingPromiseByNode(node: Node): IInitializeBindin
     resolve: resolveFn!
   };
   bindingPromiseByNode.set(node, bindingPromise);
+  if (resolvedNodes.has(node)) {
+    bindingPromise.resolve();
+  }
   return bindingPromise;
 }
 
@@ -28,6 +34,13 @@ export async function waitInitializeBinding(node: Node): Promise<void> {
 }
 
 export function resolveInitializedBinding(node: Node): void {
-  const bindingPromise = getInitializeBindingPromiseByNode(node);
-  bindingPromise.resolve();
+  // ホットパス: リスト行では全 subscriber ノードがここを通るが、await する消費者
+  // （boundComponent / shadowRoot host）はほぼ居ない。既存エントリが無ければ
+  // Promise+closure を生成せず resolve 済みマークだけ残す（15 万個級の割り当て削減）。
+  const existing = bindingPromiseByNode.get(node);
+  if (typeof existing !== "undefined") {
+    existing.resolve();
+    return;
+  }
+  resolvedNodes.add(node);
 }

--- a/packages/state/src/bindings/observerSkip.ts
+++ b/packages/state/src/bindings/observerSkip.ts
@@ -24,3 +24,42 @@ export function consumeObserverSkipOnRemove(node: Node): boolean {
   observerSkipNodes.delete(node);
   return true;
 }
+
+// framework 自身がマウント（Content.appendTo / mountAfter）したノード。
+// 追加サブツリー走査の実質の仕事は connect-snapshot 待ち（observationPending）の
+// record への配送だけで、record 自体は同期マウント（activateContent → start）で
+// observer flush より先に active 済み。よって待ちがグローバルに 1 つも無ければ
+// 追加側走査も冗長であり丸ごとスキップできる（削除側スキップの対称形）。
+// マーク〜配送が単一 microtask で外部変異が割り込めない前提も削除側と同じ。
+const observerSkipAddedNodes = new WeakSet<Node>();
+
+export function markObserverSkipOnAdd(node: Node): void {
+  observerSkipAddedNodes.add(node);
+}
+
+// マーク済みなら true を返しつつマークを消費する（削除側と同じ one-shot 契約）。
+export function consumeObserverSkipOnAdd(node: Node): boolean {
+  if (!observerSkipAddedNodes.has(node)) {
+    return false;
+  }
+  observerSkipAddedNodes.delete(node);
+  return true;
+}
+
+// connect-snapshot 待ち（two-way sync=connect で未接続のまま activate された record）の
+// グローバル件数。> 0 の間は追加側スキップを無効化して従来走査に戻す。
+// increment は settleInitialRecord、decrement は readProducerSnapshot（消化時）と
+// runTeardowns（未消化のまま終端した record のリーク防止）が担う。
+let pendingObservationCount = 0;
+
+export function incrementPendingObservation(): void {
+  pendingObservationCount++;
+}
+
+export function decrementPendingObservation(): void {
+  pendingObservationCount--;
+}
+
+export function hasPendingObservation(): boolean {
+  return pendingObservationCount > 0;
+}

--- a/packages/state/src/components/State.ts
+++ b/packages/state/src/components/State.ts
@@ -78,6 +78,9 @@ export class State extends HTMLElementBase implements IStateElement {
   // 他行を読む getter が検出されたリストパス（diff-filter 展開の全行フォールバック対象）。
   // 依存マップ（static/dynamic）と同様に追加のみ・クリアしない（安全側に固定される）。
   private _crossRowListPaths: Set<string> = new Set<string>();
+  // $1 等のインデックスを読んだ getter パス（実行時検出）。位置のみ変わった行の
+  // 静的子展開はこの集合の subtree に限定される。追加のみ・クリアしない（安全側）。
+  private _indexDependentGetterPaths: Set<string> = new Set<string>();
   private _name: string = 'default';
   private _initialized: boolean = false;
   private _initializePromise: Promise<void>;
@@ -605,6 +608,14 @@ export class State extends HTMLElementBase implements IStateElement {
 
   addCrossRowListPath(path: string): void {
     this._crossRowListPaths.add(path);
+  }
+
+  get indexDependentGetterPaths(): ReadonlySet<string> {
+    return this._indexDependentGetterPaths;
+  }
+
+  addIndexDependentGetterPath(path: string): void {
+    this._indexDependentGetterPaths.add(path);
   }
 
   bindProperty(prop: string, desc: PropertyDescriptor): void {

--- a/packages/state/src/components/types.ts
+++ b/packages/state/src/components/types.ts
@@ -32,6 +32,14 @@ export interface IStateElement {
    */
   readonly crossRowListPaths?: ReadonlySet<string>;
   addCrossRowListPath?(path: string): void;
+  /**
+   * 評価中に $1 等のインデックスを読んだ getter パスの集合（実行時検出）。
+   * 位置だけが変わった行（listDiff.changeIndexSet）は index 以外の入力が不変なので、
+   * walkDependency の静的子展開をこの集合の subtree に限定できる。
+   * optional なのはテスト用モック互換のため（undefined は「検出なし」扱い）。
+   */
+  readonly indexDependentGetterPaths?: ReadonlySet<string>;
+  addIndexDependentGetterPath?(path: string): void;
   setPathInfo(path: string, bindingType: BindingType): void;
   addStaticDependency(parentPath: string, childPath: string): boolean;
   addDynamicDependency(fromPath: string, toPath: string): boolean;

--- a/packages/state/src/dependency/walkDependency.ts
+++ b/packages/state/src/dependency/walkDependency.ts
@@ -101,6 +101,18 @@ type Context = {
 }
 
 /**
+ * 静的子展開の対象 listIndex 群。fullRows は行全体（list.* とその subtree）を展開する。
+ * movedRows は「位置だけが変わった行」で、index 以外の入力が不変なため展開を
+ * index 依存 getter の subtree（getMovedRowExpansionPaths）に限定できる。
+ */
+type ExpansionSelection = {
+  readonly fullRows: Iterable<IListIndex>,
+  readonly movedRows: Iterable<IListIndex> | null,
+}
+
+const EMPTY_INDEXES: IListIndex[] = [];
+
+/**
  * 静的子展開で訪問する listIndex 群を選ぶ。"diff" でも次の場合は全行に倒す:
  * - diff に変化が一切見えない再代入（同一参照および内容同一コピーの再代入。
  *   `arr[0].v = 5; s.items = [...arr]` のような in-place 変異後のリフレッシュ
@@ -114,28 +126,68 @@ function selectExpansionIndexes(
   _lastValue: unknown,
   _newValue: unknown,
   listDiff: IListDiff,
-): Iterable<IListIndex> {
+): ExpansionSelection {
   if (context.listExpansion === "full") {
-    return listDiff.newIndexes;
+    return { fullRows: listDiff.newIndexes, movedRows: null };
   }
   if (context.stateElement.crossRowListPaths?.has(sourcePath)) {
-    return listDiff.newIndexes;
+    return { fullRows: listDiff.newIndexes, movedRows: null };
   }
   if (listDiff.addIndexSet.size === 0 && listDiff.changeIndexSet.size === 0) {
     // 追加も移動も無い。削除も無ければ「変化が見えない再代入」= リフレッシュ意図
     if (listDiff.deleteIndexSet.size === 0) {
-      return listDiff.newIndexes;
+      return { fullRows: listDiff.newIndexes, movedRows: null };
     }
     // 削除のみ: 残存行は位置も値も不変なので展開しない
-    return listDiff.changeIndexSet;
+    return { fullRows: EMPTY_INDEXES, movedRows: null };
   }
-  if (listDiff.addIndexSet.size === 0) {
-    return listDiff.changeIndexSet;
+  return { fullRows: listDiff.addIndexSet, movedRows: listDiff.changeIndexSet };
+}
+
+const EMPTY_PATH_INFOS: IPathInfo[] = [];
+
+/**
+ * 位置だけが変わった行（movedRows）で展開すべきパス群を求める。
+ * `${listPath}.*` の静的 subtree を辿り、$1 等を読んだ実績のある getter
+ * （indexDependentGetterPaths）だけを返す。行の同一性・listIndex は保たれ
+ * index 以外の入力が不変なので、index を読まない getter / 値パスは再評価不要。
+ * 戻り値:
+ * - IPathInfo[]（空可）: この各パスだけを行の listIndex で展開する
+ * - null: ネストしたワイルドカード配下に index 依存 getter がある
+ *   （listIndex の階数が合わず個別展開できない）→ 呼び出し側で行全体展開に倒す
+ */
+function getMovedRowExpansionPaths(
+  context: Context,
+  wildcardPath: string,
+  depPathInfo: IPathInfo,
+): IPathInfo[] | null {
+  const indexGetters = context.stateElement.indexDependentGetterPaths;
+  if (!indexGetters || indexGetters.size === 0) {
+    return EMPTY_PATH_INFOS;
   }
-  if (listDiff.changeIndexSet.size === 0) {
-    return listDiff.addIndexSet;
+  let result: IPathInfo[] | null = null;
+  const queue: string[] = [wildcardPath];
+  const seen = new Set<string>(queue);
+  for (let i = 0; i < queue.length; i++) {
+    const path = queue[i];
+    if (indexGetters.has(path)) {
+      const pathInfo = getPathInfo(path);
+      if (pathInfo.wildcardCount !== depPathInfo.wildcardCount) {
+        return null;
+      }
+      (result ??= []).push(pathInfo);
+    }
+    const children = context.staticMap.get(path);
+    if (children) {
+      for (const child of children) {
+        if (!seen.has(child)) {
+          seen.add(child);
+          queue.push(child);
+        }
+      }
+    }
   }
-  return [...listDiff.addIndexSet, ...listDiff.changeIndexSet];
+  return result ?? EMPTY_PATH_INFOS;
 }
 
 type StackEntry = { address: IStateAddress, depth: number };
@@ -179,10 +231,33 @@ function _walkDependency(
           const absAddress = createAbsoluteStateAddress(absPathInfo, address.listIndex);
           const lastValue = getLastListValueByAbsoluteStateAddress(absAddress);
           const listDiff = createListDiff(address.listIndex, lastValue, newValue);
-          for(const listIndex of selectExpansionIndexes(context, sourcePath, lastValue, newValue, listDiff)) {
+          const selection = selectExpansionIndexes(context, sourcePath, lastValue, newValue, listDiff);
+          for(const listIndex of selection.fullRows) {
             const depAddress = createStateAddress(depPathInfo, listIndex);
             context.result.add(depAddress);
             nextEntries.push({ address: depAddress, depth: nextDepth });
+          }
+          if (selection.movedRows !== null) {
+            const movedPathInfos = getMovedRowExpansionPaths(context, dep, depPathInfo);
+            if (movedPathInfos === null) {
+              // ネスト配下に index 依存 getter: 安全側で行全体を展開（従来挙動）
+              for(const listIndex of selection.movedRows) {
+                const depAddress = createStateAddress(depPathInfo, listIndex);
+                context.result.add(depAddress);
+                nextEntries.push({ address: depAddress, depth: nextDepth });
+              }
+            } else if (movedPathInfos.length > 0) {
+              // 位置のみ変わった行は index 依存 getter のパスだけを展開する
+              for(const listIndex of selection.movedRows) {
+                for(const pathInfo of movedPathInfos) {
+                  const depAddress = createStateAddress(pathInfo, listIndex);
+                  context.result.add(depAddress);
+                  nextEntries.push({ address: depAddress, depth: nextDepth });
+                }
+              }
+            }
+            // movedPathInfos が空: index を読む getter が subtree に無い =
+            // 位置のみ変わった行の値は不変。展開・dirty 化とも不要。
           }
         } else {
           const depAddress = createStateAddress(depPathInfo, address.listIndex);

--- a/packages/state/src/dependency/walkDependency.ts
+++ b/packages/state/src/dependency/walkDependency.ts
@@ -360,6 +360,15 @@ export function walkDependency(
   callback: (address: IStateAddress) => void,
   options?: { listExpansion?: ListExpansion }
 ): IStateAddress[] {
+  // 依存ゼロの葉パス（staticMap / dynamicMap にエントリ無し）は context や Set を
+  // 割り当てず、開始アドレスの callback だけで完結する。リスト行の値書き込み
+  // （update ホットパス）は set 毎にここを通る。開始アドレスへの callback は
+  // 従来の walk 先頭と同一で、戻り値（依存アドレス群）も従来どおり空。
+  const startPath = startAddress.pathInfo.path;
+  if (!staticDependency.has(startPath) && !dynamicDependency.has(startPath)) {
+    callback(startAddress);
+    return [];
+  }
   const context: Context = {
     stateName: stateName,
     stateElement: stateElement,

--- a/packages/state/src/proxy/methods/setByAddress.ts
+++ b/packages/state/src/proxy/methods/setByAddress.ts
@@ -34,11 +34,51 @@ import { config } from "../../config";
 import { devtoolsSink } from "../../devtools/sink";
 import { beginPropagationTransaction, getCurrentPropagationContext } from "../../propagation/propagation";
 
-function _setByAddress(
-  target   : object, 
+// Phase 3: 書き込み時点の因果 context を update record に付与する。
+// binding 経由の書き込みは呼び出し元の dynamic scope から context を引き継ぎ、
+// binding 外からの API update は新しい transaction を開始する（設計書 §4 規則 1）。
+// 依存 walk で enqueue される派生アドレスも同じ書き込みの因果に属する。
+function notifyWrite(
   address  : IStateAddress,
   absAddress: IAbsoluteStateAddress,
-  value    : any, 
+  receiver : any,
+  handler  : IStateHandler
+): void {
+  const propagationContext = config.enablePropagationContext
+    ? (getCurrentPropagationContext() ?? beginPropagationTransaction(-1))
+    : null;
+  const updater = getUpdater();
+  updater.enqueueAbsoluteAddress(absAddress, propagationContext);
+  // 依存関係のあるキャッシュを無効化（ダーティ）、更新対象として登録
+  walkDependency(
+    handler.stateName,
+    handler.stateElement,
+    address,
+    handler.stateElement.staticDependency,
+    handler.stateElement.dynamicDependency,
+    handler.stateElement.listPaths,
+    receiver as IStateProxy,
+    "new",
+    (depAddress: IStateAddress) => {
+      // キャッシュを無効化（ダーティ）
+      if (depAddress === address) return;
+      const absDepPathInfo = getAbsolutePathInfo(handler.stateElement, depAddress.pathInfo);
+      const absDepAddress = createAbsoluteStateAddress(absDepPathInfo, depAddress.listIndex);
+      dirtyCacheEntryByAbsoluteStateAddress(absDepAddress);
+      // 更新対象として登録
+      updater.enqueueAbsoluteAddress(absDepAddress, propagationContext);
+    },
+    // リスト置換時は追加行・位置変更行のみ展開する（未変更行の再訪を省く。
+    // $postUpdate の手動リフレッシュは従来通り全行展開のまま）
+    { listExpansion: "diff" }
+  )
+}
+
+function _setByAddress(
+  target   : object,
+  address  : IStateAddress,
+  absAddress: IAbsoluteStateAddress,
+  value    : any,
   receiver : any,
   handler  : IStateHandler
 ): any {
@@ -70,38 +110,7 @@ function _setByAddress(
       }
     }
   } finally {
-    // Phase 3: 書き込み時点の因果 context を update record に付与する。
-    // binding 経由の書き込みは呼び出し元の dynamic scope から context を引き継ぎ、
-    // binding 外からの API update は新しい transaction を開始する（設計書 §4 規則 1）。
-    // 依存 walk で enqueue される派生アドレスも同じ書き込みの因果に属する。
-    const propagationContext = config.enablePropagationContext
-      ? (getCurrentPropagationContext() ?? beginPropagationTransaction(-1))
-      : null;
-    const updater = getUpdater();
-    updater.enqueueAbsoluteAddress(absAddress, propagationContext);
-    // 依存関係のあるキャッシュを無効化（ダーティ）、更新対象として登録
-    walkDependency(
-      handler.stateName,
-      handler.stateElement,
-      address,
-      handler.stateElement.staticDependency,
-      handler.stateElement.dynamicDependency,
-      handler.stateElement.listPaths,
-      receiver as IStateProxy,
-      "new",
-      (depAddress: IStateAddress) => {
-        // キャッシュを無効化（ダーティ）
-        if (depAddress === address) return;
-        const absDepPathInfo = getAbsolutePathInfo(handler.stateElement, depAddress.pathInfo);
-        const absDepAddress = createAbsoluteStateAddress(absDepPathInfo, depAddress.listIndex);
-        dirtyCacheEntryByAbsoluteStateAddress(absDepAddress);
-        // 更新対象として登録
-        updater.enqueueAbsoluteAddress(absDepAddress, propagationContext);
-      },
-      // リスト置換時は追加行・位置変更行のみ展開する（未変更行の再訪を省く。
-      // $postUpdate の手動リフレッシュは従来通り全行展開のまま）
-      { listExpansion: "diff" }
-    )
+    notifyWrite(address, absAddress, receiver, handler);
   }
 }
 
@@ -149,13 +158,83 @@ function _setByAddressWithSwap(
 }
 
 export function setByAddress(
-    target   : object, 
+    target   : object,
     address  : IStateAddress,
-    value    : any, 
+    value    : any,
     receiver : any,
     handler  : IStateHandler
 ): any {
   const stateElement = handler.stateElement;
+  const path = address.pathInfo.path;
+
+  // --- fast path: 宣言済み getter/setter でも swap 対象でもない、親を持つ葉パス ---
+  // 従来は same-value guard の値読み・hasByAddress・実書き込みがそれぞれ親チェーンを
+  // 解決していた（キャッシュヒットでも getByAddress 呼び出しの固定費 ×3）。
+  // 親を 1 回だけ解決し、同じ親オブジェクトに対して guard 判定と Reflect.set を行う。
+  // 非オブジェクト親などの例外形は従来経路へ倒し、挙動差を作らない。
+  if (!(path in target) && address.parentAddress !== null && !stateElement.elementPaths.has(path)) {
+    const parentValue = getByAddress(target, address.parentAddress, receiver, handler);
+    if (typeof parentValue === "object" && parentValue !== null) {
+      // ワイルドカード末尾で listIndex が無い不正アドレスは、従来どおり
+      // 書き込み時（enqueue 済みの try 内）に raiseError する → key は undefined のまま持ち回す
+      const lastSegment = address.pathInfo.lastSegment;
+      const key: PropertyKey | undefined = lastSegment === WILDCARD
+        ? address.listIndex?.index
+        : lastSegment;
+      let devOldValue: unknown;
+      let devHasOldValue = false;
+      if (config.sameValueGuard && (value === null || typeof value !== "object")) {
+        // hasByAddress と同じ「初期化済みスロットか」判定（undefined 格納と未初期化を区別）
+        const has = key !== undefined && key in parentValue;
+        const oldValue = key !== undefined ? (parentValue as Record<PropertyKey, unknown>)[key] : undefined;
+        if (has && Object.is(oldValue, value)) {
+          return true;
+        }
+        devOldValue = oldValue;
+        devHasOldValue = true;
+      }
+      const cacheable = address.pathInfo.wildcardCount > 0 ||
+                        stateElement.getterPaths.has(path);
+      const absPathInfo = getAbsolutePathInfo(stateElement, address.pathInfo);
+      const absAddress = createAbsoluteStateAddress(absPathInfo, address.listIndex);
+      if (devtoolsSink !== null) {
+        devtoolsSink({
+          type: "state:write",
+          absoluteAddress: absAddress,
+          value,
+          oldValue: devOldValue,
+          hasOldValue: devHasOldValue,
+        });
+      }
+      try {
+        if (key === undefined) {
+          raiseError(`address.listIndex?.index is undefined path: ${path}`);
+        }
+        return Reflect.set(parentValue, key, value);
+      } finally {
+        notifyWrite(address, absAddress, receiver, handler);
+        if (cacheable) {
+          setCacheEntryByAbsoluteStateAddress(absAddress, {
+            value: value,
+            dirty: false
+          });
+        }
+        // DCC bindable イベントディスパッチ
+        const eventName = stateElement.bindableEventMap[path];
+        if (eventName) {
+          const rootNode = stateElement.rootNode;
+          if (rootNode instanceof ShadowRoot) {
+            rootNode.host.dispatchEvent(new CustomEvent(eventName, {
+              detail: value,
+              bubbles: true,
+            }));
+          }
+        }
+      }
+    }
+  }
+  // --- end fast path ---
+
   // --- same-value guard (config.sameValueGuard・既定 ON) ---
   // primitive 値かつ Object.is 同値なら、set / enqueue / walkDependency / DOM 適用 /
   // $updatedCallback / DCC イベントを丸ごとスキップ（標準的なリアクティブ no-op）。

--- a/packages/state/src/proxy/traps/get.ts
+++ b/packages/state/src/proxy/traps/get.ts
@@ -44,6 +44,20 @@ import { IStateHandler } from "../types";
 const STREAM_STATUS_PATH_PREFIX = `${STATE_STREAM_STATUS_NAMESPACE_NAME}${DELIMITER}`;
 const STREAM_ERROR_PATH_PREFIX = `${STATE_STREAM_ERROR_NAMESPACE_NAME}${DELIMITER}`;
 
+// symbol API のクロージャは handler（= proxy と 1:1、target/receiver 不変）ごとに
+// 使い回す。drain の getValue が binding ごとに getByAddressSymbol を引くため、
+// 毎回の新規クロージャ生成が GC 圧・固定費になっていた。
+const symbolApiCacheByHandler = new WeakMap<IStateHandler, Map<symbol, unknown>>();
+
+function getSymbolApiCache(handler: IStateHandler): Map<symbol, unknown> {
+  let cache = symbolApiCacheByHandler.get(handler);
+  if (typeof cache === "undefined") {
+    cache = new Map<symbol, unknown>();
+    symbolApiCacheByHandler.set(handler, cache);
+  }
+  return cache;
+}
+
 export function get(
   target  : object, 
   prop    : PropertyKey, 
@@ -142,19 +156,27 @@ export function get(
       handler
     );
   } else if (typeof prop === "symbol") {
+    const cache = getSymbolApiCache(handler);
+    const cached = cache.get(prop);
+    if (typeof cached !== "undefined") {
+      return cached;
+    }
+    let api: unknown;
     switch (prop) {
       case setLoopContextAsyncSymbol: {
-        return (loopContext: any, callback = async (): Promise<any> => {}): Promise<any> => {
+        api = (loopContext: any, callback = async (): Promise<any> => {}): Promise<any> => {
           return setLoopContextAsync(handler, loopContext, callback);
         };
+        break;
       }
       case setLoopContextSymbol: {
-        return (loopContext: any, callback = (): any => {}): any => {
+        api = (loopContext: any, callback = (): any => {}): any => {
           return setLoopContext(handler, loopContext, callback);
         };
+        break;
       }
       case getByAddressSymbol: {
-        return (address: IStateAddress): any => {
+        api = (address: IStateAddress): any => {
           return getByAddress(
             target,
             address,
@@ -162,9 +184,10 @@ export function get(
             handler
           );
         }
+        break;
       }
       case hasByAddressSymbol: {
-        return (address: IStateAddress): boolean => {
+        api = (address: IStateAddress): boolean => {
           return hasByAddress(
             target,
             address,
@@ -172,9 +195,10 @@ export function get(
             handler
           );
         }
+        break;
       }
       case setByAddressSymbol: {
-        return (address: IStateAddress, value: any): void => {
+        api = (address: IStateAddress, value: any): void => {
           return setByAddress(
             target,
             address,
@@ -183,29 +207,32 @@ export function get(
             handler
           );
         }
+        break;
       }
       case connectedCallbackSymbol: {
-        return (): Promise<void> => {
+        api = (): Promise<void> => {
           return connectedCallback(
             target,
-            prop,
+            connectedCallbackSymbol,
             receiver,
             handler
           );
         }
+        break;
       }
       case disconnectedCallbackSymbol: {
-        return (): void => {
+        api = (): void => {
           return disconnectedCallback(
             target,
-            prop,
+            disconnectedCallbackSymbol,
             receiver,
             handler
           );
         }
+        break;
       }
       case updatedCallbackSymbol: {
-        return (
+        api = (
           refs: IAbsoluteStateAddress[]
         ): unknown => {
           return updatedCallback(
@@ -215,13 +242,17 @@ export function get(
             handler
           );
         }
+        break;
+      }
+      default: {
+        return Reflect.get(
+          target,
+          prop,
+          receiver
+        );
       }
     }
-
-    return Reflect.get(
-      target, 
-      prop, 
-      receiver
-    );
+    cache.set(prop, api);
+    return api;
   }
 }

--- a/packages/state/src/proxy/traps/get.ts
+++ b/packages/state/src/proxy/traps/get.ts
@@ -55,7 +55,15 @@ export function get(
     if (handler.addressStackLength === 0) {
       raiseError(`No active state reference to get list index for "${prop.toString()}".`);
     }
-    const listIndex = handler.lastAddressStack?.listIndex;
+    const lastAddress = handler.lastAddressStack;
+    // getter 評価中のインデックス読み取りを記録する。位置だけが変わった行
+    // （listDiff.changeIndexSet）は index 以外の入力が不変なので、walkDependency の
+    // 静的子展開を「インデックスを読んだ getter の subtree」に限定できる。
+    const lastInfo = lastAddress?.pathInfo;
+    if (lastInfo && handler.stateElement?.getterPaths.has(lastInfo.path)) {
+      handler.stateElement.addIndexDependentGetterPath?.(lastInfo.path);
+    }
+    const listIndex = lastAddress?.listIndex;
     return listIndex?.indexes[index] ?? raiseError(`ListIndex not found: ${prop.toString()}`);
   }
   if (typeof prop === "string") {

--- a/packages/state/src/structural/activateContent.ts
+++ b/packages/state/src/structural/activateContent.ts
@@ -17,11 +17,9 @@ export function activateContent(
   const bindings = getBindingsByContent(content);
   const session = getBindingSessionByContent(content);
   if (session !== null) {
-    session.initialize(bindings, {
-      registerAddress: true,
-      registerPathInfo: false,
-      applyOnReconnect: false,
-    });
+    // createContent 側の initialize で remember 済みの同一 binding 配列なので、
+    // remember を再実行しない専用パスで活性化する（リスト行生成のホットパス）
+    session.activate(bindings);
   }
   for (const binding of bindings) {
     if (session === null) {

--- a/packages/state/src/structural/createContent.ts
+++ b/packages/state/src/structural/createContent.ts
@@ -63,6 +63,37 @@ class Content implements IContent {
     this._mounted = true;
   }
 
+  tryDestroy(): boolean {
+    const session = getBindingSessionByContent(this);
+    // session 無し（SSR ハイドレーション産）や、定義待ち・connect-snapshot 待ちを
+    // 抱える content は teardown 省略でリークするため従来経路に倒す。
+    if (session === null || !session.canWholesaleDestroy()) {
+      return false;
+    }
+    session.destroyRecords();
+    for (const node of this._childNodeArray) {
+      // unmount と同じ理由の observer 向け削除マーク（clear の一括削除でも
+      // top-level node が mutation record の root に現れる）
+      markObserverSkipOnRemove(node);
+      if (node.parentNode !== null) {
+        node.parentNode.removeChild(node);
+      }
+    }
+    const bindings = getBindingsByContent(this);
+    for (const binding of bindings) {
+      if (recursiveBindingTypes.has(binding.bindingType)) {
+        const contents = getContentSetByNode(binding.node);
+        for (const content of contents) {
+          if (!content.tryDestroy()) {
+            content.unmount();
+          }
+        }
+      }
+    }
+    this._mounted = false;
+    return true;
+  }
+
   unmount(): void {
     getBindingSessionByContent(this)?.dispose();
     for(const node of this._childNodeArray) {

--- a/packages/state/src/structural/createContent.ts
+++ b/packages/state/src/structural/createContent.ts
@@ -5,7 +5,7 @@ import { getBindingSessionByContent, setBindingSessionByContent } from "../bindi
 import { setIndexBindingsByContent } from "../bindings/indexBindingsByContent.js";
 import { initializeBindingsByFragment } from "../bindings/initializeBindings.js";
 import { setNodesByContent } from "../bindings/nodesByContent.js";
-import { markObserverSkipOnRemove } from "../bindings/observerSkip.js";
+import { markObserverSkipOnAdd, markObserverSkipOnRemove } from "../bindings/observerSkip.js";
 import { INDEX_BY_INDEX_NAME } from "../define.js";
 import { raiseError } from "../raiseError.js";
 import { IBindingInfo } from "../types.js";
@@ -42,6 +42,10 @@ class Content implements IContent {
 
   appendTo(targetNode: Node): void {
     for(const node of this._childNodeArray) {
+      // framework 起点のマウントを observer に伝える。中間 fragment へ append する
+      // 経路でも、後続の一括 insertBefore(fragment) の mutation record には
+      // この top-level node が addedNodes として現れるため、ここでのマークが届く。
+      markObserverSkipOnAdd(node);
       targetNode.appendChild(node);
     }
     this._mounted = true;
@@ -52,6 +56,7 @@ class Content implements IContent {
     const nextSibling = targetNode.nextSibling;
     if (parentNode) {
       for(const node of this._childNodeArray) {
+        markObserverSkipOnAdd(node);
         parentNode.insertBefore(node, nextSibling);
       }
     }

--- a/packages/state/src/structural/getFragmentNodeInfos.ts
+++ b/packages/state/src/structural/getFragmentNodeInfos.ts
@@ -8,8 +8,26 @@ export function getFragmentNodeInfos(fragment: DocumentFragment): IFragmentNodeI
   const subscriberNodes = getSubscriberNodes(fragment);
   for(const subscriberNode of subscriberNodes) {
     const parseBindingTextResults = getParseBindTextResults(subscriberNode);
+    let node = subscriberNode;
+    // テンプレート登録時の事前正規化: text 専用の wcs-text コメントは、この時点で
+    // 空 Text に置き換えておく。行 clone は最初から Text を持ち、getBindingInfos が
+    // その Text を replaceNode に使うため、行ごとの createTextNode と start() 時の
+    // replaceChild（コメント→Text 差し替え）が丸ごと不要になる。
+    // 置換は同じ位置なので nodePath は不変。wcs-for/if 等の構造コメントは
+    // アンカーとしてコメントのまま維持する（bindingType で判別）。
+    // 非フラグメント経路（実 DOM 上のコメント）は従来どおり実行時に差し替える。
+    if (
+      subscriberNode.nodeType === Node.COMMENT_NODE
+      && parseBindingTextResults.length === 1
+      && parseBindingTextResults[0].bindingType === "text"
+      && subscriberNode.parentNode !== null
+    ) {
+      const textNode = document.createTextNode("");
+      subscriberNode.parentNode.replaceChild(textNode, subscriberNode);
+      node = textNode;
+    }
     fragmnentNodeInfos.push({
-      nodePath: getNodePath(subscriberNode),
+      nodePath: getNodePath(node),
       parseBindTextResults: parseBindingTextResults,
     });
   }

--- a/packages/state/src/structural/types.ts
+++ b/packages/state/src/structural/types.ts
@@ -7,6 +7,13 @@ export interface IContent {
   appendTo(targetNode: Node): void;
   mountAfter(targetNode: Node): void;
   unmount(): void;
+  /**
+   * wholesale 破棄: 全行クリアで再利用されない content の binding teardown
+   * （listener 解除・アドレス台帳・loopContext 掃除）を省略し、ノード・binding
+   * もろとも GC に任せる。定義待ち等の副作用がある場合は false を返し、呼び出し側が
+   * 従来経路（deactivate + unmount）で解体する。
+   */
+  tryDestroy(): boolean;
 }
 
 export interface IFragmentNodeInfo {


### PR DESCRIPTION
## Summary

Systematic jsfb (js-framework-benchmark) performance work on `@wcstack/state`, driven by a head-to-head comparison against `@wcstack/signals` on identical DOM/data. Every change was implemented, benchmarked in isolation, and kept only when it measurably improved (one candidate was reverted after measuring no gain).

### Results (median ms, same machine, back-to-back runs)

| op | main | this PR | signals | delta |
|---|---|---|---|---|
| create1k | 30.5 | ~24.6-26 | 8.0 | **-16%** |
| replace1k | 21.6 | ~17.3 | 10.0 | **-20%** |
| update10k | 10.0 | ~9.3 | 3.6 | -7% |
| remove1k | 4.4 | ~1.6 | 0.3 | **-61%** |
| append1kTo10k | 52.4 | ~45.5 | 11.0 | -13% |
| clear10k | 89.1 | ~49 | 63.2 | **-45%, now faster than signals** |

Official isKeyed classification passes throughout (swap moves 2 TRs, run recycles 1000 TRs — pooling intact).

### Changes

- **Moved-row expansion limited to index-reading getters** (8ac93764): replacing a list no longer re-evaluates every shifted row&#39;s whole static subtree. The get trap records getter paths that actually read `$1..$n` at runtime (like `crossRowListPaths`); `walkDependency` expands moved rows only for those paths, skipping the row entirely when none exist. Nested-wildcard index getters and cross-row getters keep the previous full expansion. **Intentional spec change**, unit test expectations updated accordingly.
- **Add-side MutationObserver skip for framework mounts** (bea0cc6f): symmetric twin of the PR#82 remove-side skip, gated by a pending connect-snapshot counter so two-way `sync=connect` delivery is preserved.
- **Wholesale destroy on full list clear** (8e46ee57): over-pool contents skip per-binding teardown (weak ledgers collapse with the nodes). Gated off for records with DefinitionCoordinator waiters / deferred spread tasks / pending snapshots; pool-bound contents keep full teardown.
- **Per-set fixed-cost trims** (40e0a5e7): walkDependency leaf early-return, single parent resolution in setByAddress (was 3x), symbol-API closure memoization.
- **Per-row allocation trims** (c4cf8ebb): lazy initialize-binding promises (~150k objects saved on a 10k create), frozen initial-sync policy singletons, irreversible defined-check memo in applyChange, and removal of the write-only `ResolvedAddress.paths` field (built with a `segment.length` typo).
- **Dedicated `activate()` re-activation path** (a7ec64ad): activateContent no longer re-runs `remember()` over bindings createContent just initialized.
- **Template pre-normalization** (73e0eecd): text-only `wcs-text` comments become empty Text placeholders once at fragment registration, eliminating 2 replaceChild + 2 createTextNode per cloned row. SSR unaffected (hydration contract is the `@@wcs-text-start/end` marker pair).
- **Bench infra** (cda3a4c1): signals jsfb page (Solid-idiom, shared DOM/buildData), `--page` flag for jsfb-verify.mjs, six more ops for op-profile.mjs.

A `+=` get-then-set resolution memo was implemented, measured flat on update10k, and reverted — update is bound by the two-phase drain + DOM writes, not by trap-level resolution.

## Test plan

- 1921 unit/integration tests green; coverage thresholds pass (99.61 / 98.6 / 100 / 99.78); lint clean
- New regression suites: diff-expansion index-getter filtering, add-side observer skip (incl. connect-snapshot preservation and counter leak on dispose), wholesale destroy (pool cap, nested recursion, deferred fallback, bulk-clear-unavailable route), fast-path write branches
- `e2e/bench/jsfb-verify.mjs` keyed classification + timings before/after each commit

:robot: Generated with [Claude Code](https://claude.com/claude-code)