### PR TITLE
chore: add wcstack-app skill for AI-assisted app building

### DIFF
--- a/.claude/skills/wcstack-app/SKILL.md
+++ b/.claude/skills/wcstack-app/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: wcstack-app
+description: wcstack（@wcstack/state・router・signals と wcs-fetch/wcs-storage 等の I/O ノード群）を使って Web アプリ・SPA・デモページを構築するスキル。CDN 一行読み込み・ビルドレス・標準 Web Components という設計原則に沿って、状態設計 → data-wcs バインディング → I/O ノード配線 → ルーティングの順で正確な構文のアプリを生成する。ユーザーが「wcstackでアプリを作って」「wcs-stateを使って」「data-wcsで書いて」「wcstackでSPA」「wcs-fetch/wcs-ws/wcs-storageで〜して」「signalsでアプリ」などを依頼した場合に使用する。
+---
+
+# wcstack アプリ構築スキル
+
+## 概要
+
+wcstack は「標準ファースト・ゼロコンフィグ・ビルドレス」の Web Components パッケージ群。アプリは **1 枚の HTML + CDN 一行読み込み**で完結するのが正であり、バンドラ・ビルドステップ・npm install を持ち込まないこと（ユーザーが明示的に要求した場合を除く）。
+
+生成コードの精度は構文の正確さで決まる。**このファイルは進め方と鉄則のみ**を持ち、正確な構文は同ディレクトリの references/ に分離してある。該当フェーズに入ったら必ず対応するリファレンスを読むこと:
+
+| ファイル | 読むタイミング |
+|---|---|
+| `references/state-binding.md` | `<wcs-state>`・`data-wcs`・フィルタ・command/event-token を書く前 |
+| `references/router-and-scaffold.md` | SPA / ルーティング / autoloader / index.html 骨格・サーバーを書く前 |
+| `references/io-node-catalog.md` | I/O ノード（wcs-fetch 等 35 タグ）の配線前・signals でアプリを書く前 |
+
+## ワークフロー
+
+### 1. スタック選択（state か signals か）
+
+- **`@wcstack/state`（既定）** — HTML の `data-wcs` パス文字列で UI と状態を接続。JS にリアクティブプリミティブが現れない。フォーム・リスト・CRUD などの一般的なアプリはこちら。
+- **`@wcstack/signals`** — `signal()`/`computed()`/`effect()`/`h()` を JS で直接書く。DSL を避けたい・ロジック中心・型を効かせたい場合。深いパス追跡は無い（それは state の領分）。
+- 両者は**併存**（競合ではない）。ただし 1 アプリでは片方に決めるのが原則。
+
+### 2. HTML 骨格（CDN 読み込み規約）
+
+```html
+<!-- state 系: パッケージごとに /auto 一行。I/O ノードは state より先に並べる -->
+<script type="module" src="https://esm.run/@wcstack/fetch/auto"></script>
+<script type="module" src="https://esm.run/@wcstack/router/auto"></script>
+<script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+```
+
+- signals 系は **`@wcstack/signals/dom` 単一エントリのみ**から import する（`.` と `.dom` を CDN で混在させるとリアクティブコアが二重化して壊れる）。
+- SPA なら `<head>` に **`<base href="/">` が必須**（無いとディープリンク時に basename 誤導出で壊れる）。
+
+### 3. 状態設計（state 系）
+
+状態は plain object の `export default`。computed はドットパス文字列キーの getter（`get "cart.total"()`、ワイルドカード `get "users.*.fullName"()`）。設計時に決めること:
+
+- I/O ノード 1 つにつき state に 1 スロット（`listFetch: { value: null, loading: false, error: null, status: 0 }`）
+- `for:` に渡すパスは配列必須なので、fetch の value 等 null になりうるものは `get rows() { return this["listFetch.value"] ?? []; }` の派生 getter を挟む
+- 要素→state の出力（output-only プロパティ）には都合のよい初期値をシードしない（要素側が authority。実初期値 `null`/`false` でシード）
+
+### 4. バインディング → I/O 配線 → ルーティング
+
+各リファレンスを読んで書く。I/O ノードとの配線は 4 形態:
+
+1. プロパティバインド: `data-wcs="value: users; loading: busy"`
+2. spread: `data-wcs="...: listFetch"`（wcBindable 全 properties+inputs 一括。commands/event は対象外）
+3. command-token（state→要素）: `data-wcs="command.fetch: $command.refresh"` + `$commandTokens`
+4. event-token（要素→state）: `data-wcs="eventToken.value: responded"` + `$eventTokens` + `$on`
+
+### 5. サーバーと動作確認
+
+- 静的 1 ページなら不要（file:// でも動くが fetch を使うなら簡易サーバー推奨）
+- SPA は「拡張子なし・非 API の GET すべてに index.html を返す」フォールバックが必須（実装例は router-and-scaffold.md §7）
+- 完成後はブラウザまたは簡易サーバー起動で最低限の動作確認をする。参考実装が必要なら wcstack リポジトリの `examples/`（複合デモ）と `packages/*/examples/`（単機能デモ）を見る
+
+## 鉄則チェックリスト（違反すると静かに壊れる）
+
+書き終えたら必ずこの表で自己レビューする:
+
+1. **状態更新はパス代入** — `this["user.name"] = v` ✅ / `this.user.name = v` ❌（検知されない）
+2. **配列は新配列を再代入** — `toSpliced`/`concat`/`filter`/`toSorted` ✅ / `push`/`splice`/`sort` ❌
+3. `onclick:` はメソッド名のみで**引数を渡せない** — 引数違いはゼロ引数ラッパーメソッドを作る
+4. command バインド右辺は必ず `$command.<name>`（ベア名不可）。`eventToken.` のキーは生イベント名でなく **wcBindable プロパティ名**
+5. `else:` は末尾コロン必須。複数バインディングの区切りは `;`
+6. `wcs-fetch:response` は**エラー時も発火** — `$on` 側で `event.detail.status` を確認
+7. **router がスタンプするノードに `data-wcs` を書かない** — state はバインド時点の DOM しか見ない。データバインドされるページは body 直下の `<template data-wcs="if: ...">` に置き、ルート内は `<wcs-head>` + 静的コンテンツのみ
+8. リンクは `<a>` でなく `<wcs-link to="...">`（basename 自動付与・`active` クラス）
+9. storage バインド先スロットは `undefined` で初期化（`""`/`null` だと保存値を初期書き戻しで上書き）
+10. カスタムフィルタ登録 API は**存在しない** — 組み込み 40 種（references 参照）で書けない変換は getter で行う
+11. 生ハンドル（MediaStream 等）は state に入れない — `eventToken` → `$command.attachStream` で要素間直結
+12. `trigger` はコマンドでなくモーメンタリ入力 — `false`→`true` の書き込みで起動
+
+## 最小テンプレート（起点）
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+</head>
+<body>
+<wcs-state>
+  <script type="module">
+    export default {
+      count: 0,
+      countUp() { this.count++; }
+    };
+  </script>
+</wcs-state>
+<p>Count: {{ count }}</p>
+<button data-wcs="onclick: countUp">+1</button>
+</body>
+</html>
+```
+
+SPA・fetch 連携・レイアウトを含むフル雛形は `references/router-and-scaffold.md` §7 の router-spa 実物骨格を起点にする。

--- a/.claude/skills/wcstack-app/references/io-node-catalog.md
+++ b/.claude/skills/wcstack-app/references/io-node-catalog.md
@@ -1,0 +1,202 @@
+# wcstack I/O ノードカタログ + signals 早見表
+
+出典: 各パッケージ README（ja 優先）と src の `static wcBindable` 宣言・`packages/signals/README.ja.md`・`examples/signals-live-search`。fetch / storage / websocket / timer / intersection / clipboard / notification / geolocation は README と突き合わせ済み。それ以外の属性 kebab-case 表記は inputs 名からの推定を含むため、厚く使う場合は該当パッケージの README を確認すること。
+
+## 0. 共通規約（全 I/O ノード共通)
+
+- **CDN 一行**: `<script type="module" src="https://esm.run/@wcstack/<pkg>/auto"></script>`（`@wcstack/state/auto` と併記、I/O 側を先に）
+- **wc-bindable**: 各タグは `static wcBindable` で **properties**（観測可能な出力。state が購読）/ **inputs**（書き込みサーフェス。属性は kebab-case ミラー）/ **commands**（呼び出し可能メソッド）を宣言。
+- **配線**: 出力バインド `data-wcs="value: users"` ／ command-token `data-wcs="command.<メソッド>: $command.<名前>"` ／ event-token `data-wcs="eventToken.<プロパティ>: <名前>"` ／ spread `data-wcs="...: slot"`。
+- **共通イディオム**:
+  - `manual` 属性 = 接続時に自動開始しない。
+  - `trigger` はコマンドではなく**モーメンタリな入力プロパティ**。`false`→`true` の書き込みで起動（`command.trigger` は存在しない）。
+  - イベント名は `<タグ名>:<種別>`（例外: screen-orientation は `wcs-orientation:*`、`<wcs-throttle>` は `wcs-throttle:*`）。
+  - ほぼ全ノードが `error` / `errorInfo` を出力に持つ（持たないのは timer / raf / debounce / permission / network / intersection / resize / defined）。表では省略。
+
+## 1. カタログ
+
+| パッケージ | タグ | 主要属性 / inputs | properties（出力） | commands |
+|---|---|---|---|---|
+| **fetch** | `<wcs-fetch>`（補助: `<wcs-fetch-header name value>` `<wcs-fetch-body type>` `<wcs-infinite-scroll>`） | `url` `method` `target` `manual` `body` `response-type`(auto/json/text/blob/arrayBuffer) `trigger` | `value` `loading` `error` `status` `objectURL` `trigger` | `fetch` `abort` |
+| **storage** | `<wcs-storage>` | `key` `type`(local/session) `value` `manual` `trigger` | `value` `loading` `error`（クロスタブ同期あり） | `load` `save` `remove`（全て同期） |
+| **upload** | `<wcs-upload>` | `url` `method` `field-name` `multiple` `max-size` `accept` `manual` `files` `trigger` | `value` `loading` `progress` `error` `status` `files` `trigger` | `upload` `abort` |
+| **websocket** | `<wcs-ws>` | `url` `protocols` `auto-reconnect` `reconnect-interval` `max-reconnects` `binary-type` `manual` `trigger` `send`（値を書くと即送信・オブジェクトは自動 JSON 化） | `message` `connected` `loading` `readyState` `trigger` `send` | `connect` `sendMessage` `close` |
+| **sse** | `<wcs-sse>` | `url` `with-credentials` `events` `raw` `manual` `trigger` | `message` `connected` `loading` `readyState` `trigger` | `connect` `close`（受信専用） |
+| **broadcast** | `<wcs-broadcast>` | `name` `manual` | `message`（自己エコーなし・structured clone） | `open` `post` `close` |
+| **worker** | `<wcs-worker>` | `src` `type` `name` `manual` `keep-alive` `restart-on-error` `max-restarts` `restart-interval` | `message` `running` | `start` `post` `terminate` |
+| **timer** | `<wcs-timer>` | `interval`(既定1000) `once` `repeat` `immediate` `manual` `trigger` | `tick`(カウンタ) `elapsed`(ms) `running` `trigger` | `start` `stop` `reset` `pause` `resume` |
+| **raf** | `<wcs-raf>` | `once` `repeat` `manual` `trigger` | `tick` `elapsed` `dt` `running` `suspended` | `start` `stop` `reset` `pause` `resume` |
+| **debounce** | `<wcs-debounce>` / `<wcs-throttle>`（throttle は leading 既定 on・`wcs-throttle:*`） | `source`（値サーフェス入力） `wait` `leading` `trailing` `max-wait` | `value`(settled 済み値) `fired` `pending` | `trigger` `cancel` `flush` |
+| **clipboard** | `<wcs-clipboard>` | `monitor` | `text` `items` `loading` `readPermission` `writePermission` `monitoring` `copied` `cut` `pasted` | `writeText` `write` `readText` `read` `startMonitor` `stopMonitor`（write はユーザージェスチャ必須） |
+| **geolocation** | `<wcs-geo>` | `high-accuracy` `timeout` `maximum-age` `watch` `manual` `trigger`（属性は接続時読み取り） | `position` `latitude` `longitude` `accuracy` `coords` `timestamp` `watching` `loading` `permission` | `getCurrentPosition` `watchPosition` `clearWatch` |
+| **permission** | `<wcs-permission>` | `name`（1タグ1権限） `user-visible-only` `sysex` | `state`(granted/denied/prompt/unsupported) `granted` `denied` `prompt` `unsupported` | なし（監視専用） |
+| **notification** | `<wcs-notify>` | `notice`（reactive 表示・同値ガード） `mode`(auto/constructor/sw) `body` `icon` `badge` `tag` `lang` `dir` `require-interaction` `silent` `renotify` `manual` | `permission` `granted` `denied` `prompt` `unsupported` `clicked` `closed` `shown` | `request` `notify(title, options)` `close` `closeAll`（SW 併用は `@wcstack/notification/sw` の `wireNotificationClicks()`） |
+| **intersection** | `<wcs-intersect>` | `target`（省略=最初の子/セレクタ/`self`） `root` `root-margin` `threshold` `once` `manual` `trigger` | `entry` `intersecting` `ratio` `visible`（初交差でラッチ） `observing` | `observe` `reobserve` `unobserve` `disconnect` `reset` |
+| **resize** | `<wcs-resize>` | `target` `box` `round` `once` `manual` `trigger` | `entry` `width` `height` `observing` | `observe` `unobserve` `disconnect` |
+| **wakelock** | `<wcs-wakelock>` | `active`（desired 入力） `type` `manual` | `held`（actual 出力・OS 解放を反映） | `request` `release` |
+| **camera** | `<wcs-camera>` | `audio` `facing-mode` `device-id` `width` `height` `autostart` `keep-alive` | `active` `permission` `audioPermission` `deviceId` `devices` `streamReady`（生 MediaStream） `ended` | `start` `stop` `switchCamera` |
+| **camera** | `<wcs-recorder>` | `mime-type` `timeslice` `audio-bits-per-second` `video-bits-per-second` | `recording` `paused` `duration` `mimeType` `blob` `objectURL` `recorded` `dataavailable` | `attachStream` `start` `stop` `pause` `resume` |
+| **speech** | `<wcs-speak>`（TTS） | `say`（reactive 発話・同値ガード） `rate` `pitch` `volume` `voice` `lang` `manual` | `voices` `speaking` `paused` `pending` `charIndex` `spokenWord` `unsupported` | `speak`（imperative・同値でも発火） `cancel` `pause` `resume` |
+| **speech** | `<wcs-listen>`（STT） | `lang` `continuous` `interim` `max-restarts` `manual` `trigger` | `interimTranscript` `finalTranscript` `result` `listening` `permission` `unsupported` `trigger` | `start` `stop` `abort` |
+| **defined** | `<wcs-defined>` | `tags` `mode` `timeout`（timeout でロード失敗検出） | `defined` `pending` `missing` `count` `total` `error`（不変条件 total=count+pending+missing） | なし（event-token 専用・単調・終端） |
+| **fullscreen** | `<wcs-fullscreen>` | `target` | `active` | `requestFullscreen` `exitFullscreen` |
+| **picture-in-picture** | `<wcs-pip>` | `target` | `active` | `requestPictureInPicture` `exitPictureInPicture` |
+| **pointer-lock** | `<wcs-pointer-lock>` | `target` | `active` | `requestPointerLock` `exitPointerLock` |
+| **screen-orientation** | `<wcs-screen-orientation>` | （入力なし） | `type` `angle` `portrait` `landscape` | `lock` `unlock` |
+| **idle** | `<wcs-idle>` | `threshold` | `userState` `screenState` `active` | `requestPermission` `start` `stop` |
+| **network** | `<wcs-network>` | （入力なし） | `effectiveType` `downlink` `rtt` `saveData` `supported` | なし（監視専用） |
+| **share** | `<wcs-share>` | （入力なし） | `value` `loading` `cancelled` | `share` |
+| **contacts** | `<wcs-contacts>` | （入力なし） | `value` `loading` `cancelled` | `select` |
+| **credential** | `<wcs-credential>` | （入力なし） | `value` `loading` `cancelled` | `get` `store` |
+| **eyedropper** | `<wcs-eyedropper>` | （入力なし） | `value` `loading` `cancelled` | `open` `abort` |
+| **tilt** | `<wcs-tilt>` | （入力なし） | `alpha` `beta` `gamma` `absolute` `permissionState` | `requestPermission` `start` `stop` |
+| **accelerometer** | `<wcs-accelerometer>` | `frequency` | `x` `y` `z` | `start` `stop` |
+| **gyroscope** | `<wcs-gyroscope>` | `frequency` | `x` `y` `z` | `start` `stop` |
+| **magnetometer** | `<wcs-magnetometer>` | `frequency` | `x` `y` `z` | `start` `stop` |
+| **ambient-light-sensor** | `<wcs-ambient-light-sensor>` | `frequency` | `illuminance` | `start` `stop` |
+
+## 2. 高頻度ノードの state 連携最小例（各 README より）
+
+**fetch** — 算出 URL が fetch を駆動（url 変化で自動再実行・進行中は abort）:
+```html
+<wcs-fetch data-wcs="url: usersUrl; value: users; loading: listLoading; error: listError"></wcs-fetch>
+<ul><template data-wcs="for: users"><li data-wcs="textContent: users.*.name"></li></template></ul>
+```
+
+**storage** — プリミティブ値の双方向永続化。バインド先 state スロットは**意図的に `undefined` で初期化**（`""`/`null` だと初期書き戻しで保存値を上書きする = load-before-bind イディオム）:
+```html
+<wcs-storage key="username" data-wcs="value: username"></wcs-storage>
+<input data-wcs="value: username">
+```
+オブジェクトのサブプロパティ変更は `$trackDependency` 入り getter を `trigger` にバインドし `manual` + save で保存。
+
+**websocket** — 受信は `message`、送信は `send` に値を書くだけ:
+```html
+<wcs-ws url="wss://example.com/ws"
+  data-wcs="message: lastMessage; connected: isConnected; send: outgoing"></wcs-ws>
+<!-- state 側: sendChat() { this.outgoing = { type: "chat", content: this.chatInput }; } -->
+```
+
+**timer** — `setInterval` 相当を宣言的に:
+```html
+<wcs-timer interval="1000" data-wcs="tick: count; running: isRunning"></wcs-timer>
+<!-- ワンショット: <wcs-timer interval="3000" once data-wcs="tick: showBanner"> -->
+```
+
+**intersection** — 遅延読み込み（`visible` は初交差でラッチ、`once` で切断）:
+```html
+<wcs-intersect once data-wcs="visible: shown">
+  <img data-wcs="src: src" alt="lazy">
+</wcs-intersect>
+<!-- 無限スクロール端検出: <wcs-intersect target="self" data-wcs="intersecting: atEnd"> -->
+```
+
+**clipboard** — command-token でコピー（write はユーザージェスチャ必須）:
+```html
+<wcs-clipboard data-wcs="command.writeText: $command.copy"></wcs-clipboard>
+<button data-wcs="onclick: onShare">Share</button>
+<!-- state 側: $commandTokens: ["copy"], onShare() { this.$command.copy.emit(this.message); } -->
+```
+読み取りは `command.readText: $command.paste; text: pasted`、監視は `monitor` 属性 + `eventToken.pasted: ...`。
+
+**notification** — command-token（表示）と event-token（クリック）が 1 タグに同居:
+```html
+<wcs-notify data-wcs="
+  command.request: $command.request;
+  command.notify:  $command.notify;
+  eventToken.clicked: opened"></wcs-notify>
+<!-- state 側: $commandTokens:["request","notify"], $eventTokens:["opened"],
+     send() { this.$command.notify.emit("New message", { body:"...", tag:"chat", data:{room:7} }); },
+     $on: { opened: (state, event) => { /* event.detail = {tag,data,action} */ } } -->
+```
+reactive 版は `notice` 属性バインド（同値抑制つき。スパム防止に debounce + `tag` 推奨）。
+
+**camera/recorder** — 生 MediaStream は state に入れず要素間直結:
+```html
+<wcs-camera data-wcs="eventToken.streamReady: streamReady"></wcs-camera>
+<wcs-recorder data-wcs="command.attachStream: $command.attachStream"></wcs-recorder>
+<!-- $on: { streamReady: (state, ev) => state.$command.attachStream.emit(ev.detail) } -->
+```
+
+## 3. signals 早見表（`@wcstack/signals`）
+
+### 位置づけ（state との使い分け）
+
+- `@wcstack/state` は UI と状態を **HTML のパス文字列**（`data-wcs`）で接続し、コードにリアクティブプリミティブは現れない。`@wcstack/signals` は逆に **signal/computed/effect を直接露出**（DSL・`data-wcs` なし）。両者は競合ではなく**併存**。
+- signals の v1 スコープ外: SSR/hydration・深い/proxy リアクティビティ（パスベース深追跡は state の領分）・ストリーム backpressure。
+- API は TC39 Signals proposal の形に倣った自前極小実装。
+
+### CDN 読み込み（1 ページ 1 エントリの原則）
+
+```html
+<script type="importmap">
+{ "imports": { "@wcstack/signals/dom": "https://esm.run/@wcstack/signals/dom" } }
+</script>
+<script type="module">
+  import { signal, computed, effect, h, render, For, bindNode } from "@wcstack/signals/dom";
+</script>
+```
+
+> **既知の罠**: CDN では各エントリがコア内蔵の自己完結バンドルになるため、`@wcstack/signals` と `@wcstack/signals/dom` を 1 ページで混在 import すると**リアクティブコアが二重化**して継ぎ目で反応性が壊れる。CDN ページでは全てを単一の `/dom` エントリから import する（`/dom` はコア全体を再エクスポート）。ローカル npm / バンドラではこの制約なし。
+
+### 基本 API（コア）
+
+```js
+const count = signal(0);                       // .get()=読み取り+追跡 / .peek()=追跡なし / .set(v)
+const doubled = computed(() => count.get() * 2); // 遅延・メモ化・equality short-circuit
+effect(() => { console.log(doubled.get()); });   // 初回即時、以降マイクロタスクに coalesce
+count.set(1);        // 次のマイクロタスクで effect 再実行
+flushSync();         // 同期フラッシュ（テストで DOM を読み戻す時）
+createRoot((dispose) => { /* この中の effect/リソースは dispose で一括破棄 */ });
+onCleanup(fn);       // 現在のオーナーに破棄処理を登録
+```
+
+### DOM レイヤ（`h` / `render` / `SignalsElement`）
+
+`h(tag, props, ...children)` は実 DOM を一度だけ構築、関数/signal の prop・child だけが個別 effect で更新（VDOM なし）。`onXxx` prop はイベントリスナ。カスタム要素は `SignalsElement` を継承して `render()` のみ実装（connect でマウント・disconnect で全 effect 破棄）。
+
+### keyed リスト — `For` / `Index`
+
+```js
+const todos = signal([{ id: 1, text: "a" }, { id: 2, text: "b" }]);
+h("ul", null, For(todos, (t, index) => h("li", null, () => `${index()}: ${t.text}`), { key: (t) => t.id }));
+// プリミティブ配列は Index: each は (item: () => T, index: number)
+h("ul", null, Index(nums, (n) => h("li", null, () => String(n() * 2))));
+```
+
+素のリアクティブ child（`() => items.map(render)`）は毎回全再生成するのでリストには必ず For/Index。キー既定は `===`、重複キーは throw。`each` は単一 Node を返す。
+
+### 非同期 — `resource` / `streamResource`
+
+```js
+const user = resource(
+  async (userId, signal) => (await fetch(`/api/users/${userId}`, { signal })).json(),
+  { args: () => id.get() },  // args 内で読んだ signal 変化 → 前を abort して再起動（switchMap）
+); // user.value / user.loading / user.error は読み取り専用 signal
+
+const log = streamResource((args, signal) => openLogStream(signal), {
+  fold: (acc, chunk) => [...(acc ?? []), chunk], initial: [],
+}); // log.value / log.status ("idle"|"active"|"done"|"error") / log.error。backpressure なし・fold は有界に
+```
+
+強い契約: `source` は渡される `AbortSignal` を必ず honor すること（これが restart/dispose を駆動）。
+
+### wc-bindable ブリッジ — `bindNode`（I/O ノードを signal 化）
+
+```js
+await customElements.whenDefined("wcs-fetch");
+const bound = bindNode(fetchEl);              // descriptor は constructor.wcBindable から自動取得
+bound.signals.value.get();                    // 出力 property → 読み取り専用 signal（同値ガード）
+bound.on("fired", { fold, initial });         // event-token ストリーム（同値でも毎回）
+bound.set("url", v);                          // input へ命令的書き込み
+bound.bindInput("url", someSignal);           // signal → input のリアクティブ反映（ループはガード）
+bound.command("fetch", ...args);              // command 呼び出し
+bound.bindCommand("start", trigger, mapArgs); // trigger 変化で command 起動（初期値では発火しない）
+bound.dispose();                              // 全解除（冪等・以後 inert）
+```
+
+型付けは `bindNode<FetchShape>(el)`。実戦パターン: `effect(() => bound.set("url", ...))` で query → `<wcs-fetch>` 自動 fetch → `bound.signals.value` を `computed` で読み `For` で描画（examples/signals-live-search）。
+
+### 安定度
+
+コア（signal/computed/effect/createRoot/onCleanup/flushSync）と resource/streamResource は **Stable**。`bindNode`/`nodeSource` と DOM レイヤ（h/For/Index/SignalsElement）は **Evolving**（マイナーで変わりうる）。

--- a/.claude/skills/wcstack-app/references/router-and-scaffold.md
+++ b/.claude/skills/wcstack-app/references/router-and-scaffold.md
@@ -1,0 +1,388 @@
+# wcstack router / autoloader / アプリ雛形 リファレンス
+
+出典: `packages/router/README.ja.md`・`packages/autoloader/README.ja.md`・ルート `README.md`・`examples/README.ja.md`・`examples/router-spa/`（index.html / server.js / README.ja.md）・`packages/router/src/`。すべて実ファイル確認済み。
+
+## 1. SPA の最小雛形
+
+### CDN 読み込み（1 パッケージ 1 行、`/auto` エントリ）
+
+```html
+<script type="module" src="https://esm.run/@wcstack/fetch/auto"></script>
+<script type="module" src="https://esm.run/@wcstack/router/auto"></script>
+<script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+```
+
+`/auto` は登録のみ行うゼロコンフィグ・ブートストラップ。I/O ノード系を state より先に並べるのがベストプラクティス（state は whenDefined で保留するため必須要件ではない）。
+
+### ルーターの基本構造
+
+**`<wcs-router>` の直下に `<template>` が必須**。その中に `<wcs-route>` を並べる。表示先は `<wcs-outlet>`（HTML に書かなければ router が自動生成）。
+
+```html
+<wcs-router>
+  <template>
+    <wcs-route path="/">
+      <wcs-head><title>Home</title></wcs-head>
+      <app-home></app-home>
+    </wcs-route>
+    <wcs-route path="/about">
+      <about-page></about-page>
+    </wcs-route>
+    <wcs-route fallback>
+      <error-404></error-404>
+    </wcs-route>
+  </template>
+</wcs-router>
+<wcs-outlet></wcs-outlet>
+```
+
+- コンポーネント表示 = **`<wcs-route>` の子要素として直接書く**。マッチ時に子要素が `<wcs-outlet>` へスタンプされる。
+- 静的 HTML（`data-wcs` なし）をルート内に直接書いてもよい。
+
+### `<wcs-route>` 属性一覧
+
+| 属性 | 説明 |
+|------|------|
+| `path` | トップレベルは `/` 始まりの絶対パス、ネスト時は相対パス。パラメータは `:名前`。キャッチオールは `*`。トップレベルに相対パスは不可 |
+| `index` | 上位のパスを引き継ぐ（親パスそのものにマッチ） |
+| `fallback` | どのルートにもマッチしない場合に表示 |
+| `fullpath` | 上位を含むフルパス（読み取り専用） |
+| `name` | 識別用 |
+| `guard` | ガード有効化。値はガードキャンセル時のリダイレクト先絶対パス |
+
+プロパティ: `params`（文字列パラメータ）/ `typedParams`（型変換済み）/ `guardHandler`。
+
+### マッチング優先順位
+
+1. セグメント数が多い方 → 2. 静的セグメントが多い方（`"users"` > `":id"` > `"*"`）→ 3. 定義順。`/products` と `/products/` は同一扱い。
+
+## 2. 型付きパスパラメータ
+
+構文: `:パラメータ名(型名)`
+
+```html
+<wcs-route path="/users/:userId(int)"><user-detail data-bind="props"></user-detail></wcs-route>
+<wcs-route path="/posts/:date(isoDate)/:slug(slug)"><post-detail data-bind="props"></post-detail></wcs-route>
+```
+
+| 型名 | 説明 | 変換後の型 |
+|------|------|------|
+| `int` | 整数 | `number` |
+| `float` | 浮動小数点数 | `number` |
+| `bool` | `true`/`false`/`0`/`1` | `boolean` |
+| `uuid` | UUID v1-5 | `string` |
+| `slug` | 小文字英数字とハイフン | `string` |
+| `isoDate` | ISO 8601 日付 | `Date` |
+| `any` | 任意文字列（デフォルト） | `string` |
+
+型不一致の値は**そのルートにマッチしない**（エラーにならず他ルートや fallback に落ちる）。未知の型名は `any` にフォールバック。
+
+### パラメータの受け取り方
+
+**(a) JS から**: `route.params.userId`（文字列）/ `route.typedParams.userId`（型変換済み）。
+
+**(b) `data-bind` 自動バインディング** — ルート内の要素にパラメータを自動注入:
+
+| `data-bind` の値 | 動作 |
+|------|------|
+| `"props"` | `element.props` にマージ |
+| `"states"` | `element.states` にマージ |
+| `"attr"` | `setAttribute()` で設定 |
+| `""`（空文字） | 直接プロパティ（`element.userId = value`） |
+
+パラメータは `connectedCallback` 発火前に割り当て。未定義カスタム要素は `customElements.whenDefined()` 解決後に遅延割り当て（autoloader と共存可能）。
+
+**(c) state から（wc-bindable 経由）** — `<wcs-router>` の `path` 出力から getter で導出（§5・§7 参照）。
+
+## 3. ネストレイアウトと `<wcs-head>`
+
+### `<wcs-layout>`
+
+テンプレートを読み込み、子要素を `<slot>` に挿入して `<wcs-layout-outlet>` へ書き出す。
+
+| 属性 | 説明 |
+|------|------|
+| `layout` | テンプレートとなる `<template>` の id |
+| `src` | 外部ファイルテンプレートの URL |
+| `name` | 識別名 |
+| `enable-shadow-root` / `disable-shadow-root` | outlet の Shadow/Light DOM 切替 |
+
+### ルート×レイアウト混在の実例
+
+```html
+<wcs-router>
+  <template>
+    <wcs-route path="/">
+      <wcs-layout layout="main-layout">
+        <main-header slot="header"></main-header>
+        <main-body>
+          <wcs-route index>
+            <wcs-head><title>Main Page</title></wcs-head>
+            <main-dashboard></main-dashboard>
+          </wcs-route>
+          <wcs-route path="products">          <!-- ネストは相対パス -->
+            <wcs-route index><product-list></product-list></wcs-route>
+            <wcs-route path=":productId"><product-item data-bind="props"></product-item></wcs-route>
+          </wcs-route>
+        </main-body>
+      </wcs-layout>
+    </wcs-route>
+    <wcs-route fallback><error-404></error-404></wcs-route>
+  </template>
+</wcs-router>
+<wcs-outlet></wcs-outlet>
+
+<template id="main-layout">
+  <section><h1> Main </h1><slot name="header"></slot></section>
+  <section><slot></slot></section>   <!-- デフォルトスロットにルート内容が入る -->
+</template>
+```
+
+### Light DOM の制限
+
+`disable-shadow-root` ではスロット置換は **`<wcs-layout>` の直接の子要素のみ**が対象。`<wcs-route>` の中の `slot` 属性付き要素はスロットに入らない。
+
+### `<wcs-head>`
+
+ルートごとにドキュメント `<head>` を管理。スタックベースで最後に接続されたものが優先。対応要素: `<title>` `<meta>` `<link>` `<base>` `<script>` `<style>`。全 `<wcs-head>` 切断で初期状態に復元。`<meta>` は `name`/`property`/`http-equiv`、`<link>` は `rel`/`href` で識別。
+
+## 4. ガード・basename・フォールバック
+
+### ルートガード
+
+```html
+<wcs-route path="/dashboard" guard="/login">
+  <wcs-guard-handler>
+    <script type="module">
+      export default function(toPath, fromPath) {
+        return document.cookie.includes('session=');   // boolean | Promise<boolean>
+      }
+    </script>
+  </wcs-guard-handler>
+  <dashboard-page></dashboard-page>
+</wcs-route>
+```
+
+`false` でキャンセル → `guard` 属性のパスへ遷移。`<wcs-guard-handler>` はパース後 DOM から除去。`<wcs-route>` 外に置くと無視。JS からは `route.guardHandler = fn` でも設定可。
+
+### basename
+
+```html
+<wcs-router basename="/app"> ... </wcs-router>
+```
+
+決定順: ① `basename` 属性 → ② `<base href>` から導出 → ③ 空文字。正規化: 先頭 `/` 付与・連続スラッシュ畳み込み・末尾 `/` 削除・`*.html` 末尾削除（`/app/index.html` → `/app`）。basename が異なれば同一ドキュメントに複数 Router 共存可。
+
+### フォールバック / キャッチオール
+
+- `<wcs-route fallback>` — 404 用。
+- `path` 末尾の `*` は残りパス全体にマッチ、取得は `params['*']`、優先度最低。
+
+## 5. ナビゲーション
+
+### 宣言的リンク: `<wcs-link>`（生の `<a>` ではなくこれを使う）
+
+```html
+<wcs-link to="/">Products</wcs-link>
+<wcs-link to="/about">About</wcs-link>
+```
+
+- `<a>` に変換。`to` が `/` 始まりならルートパス（basename 自動付与）、それ以外は外部 URL 扱い。
+- 現在地一致で `active` CSS クラス自動付与: `a.active { font-weight: bold; }`
+
+### プログラム的ナビゲーション
+
+**(a) JS API**: router 要素の `async navigate(path: string): Promise<void>`（Navigation API、なければ pushState フォールバック）。
+
+**(b) state から** — `<wcs-router>` の wc-bindable 面は `path`（output-only）と `navigateUrl`（input/output 両対応）:
+
+```html
+<wcs-router data-wcs="path: path; navigateUrl: navigateUrl">
+```
+
+```javascript
+export default {
+  path: "",          // router → state（現在パスが流れ込む）
+  navigateUrl: null, // state → router（代入で遷移）
+  openProduct() { this.navigateUrl = "/products/" + this["products.*.id"]; },
+  goToProducts() { this.navigateUrl = "/"; },
+};
+```
+
+- `navigateUrl` は**自己リセット**: 遷移完了時に router が `null` に戻すので、同じパスの再代入でも再遷移する。
+- `path` は output-only なので state から書き戻さない（router が authority。バインディング確立時に現在値を読むためディープリンクでも取りこぼしなし）。
+
+## 6. autoloader
+
+### Import Map + 要素配置
+
+```html
+<script type="importmap">
+  {
+    "imports": {
+      "@components/ui/": "./components/ui/",
+      "@components/app/": "./components/app/"
+    }
+  }
+</script>
+<script type="module" src="https://esm.run/@wcstack/autoloader/auto"></script>
+<body>
+  <wcs-autoloader></wcs-autoloader>   <!-- ロードライフサイクルのトリガー。必須 -->
+  <ui-button></ui-button>    <!-- ./components/ui/button.js を自動 import -->
+  <app-header></app-header>  <!-- ./components/app/header.js を自動 import -->
+</body>
+```
+
+### 解決規則
+
+**遅延読み込み（名前空間）** — キーが `/` で終わる: `"@components/<プレフィックス>[|<ローダー>]/": "<パス>"`
+- タグ名のプレフィックス部がマッチし残りがファイル名: `@components/ui/` + `<ui-button>` → `./components/ui/button.js`
+- プレフィックス内のスラッシュはダッシュに変換。ローダー指定: `"@components/ui|lit/": "./ui/"`（デフォルト `vanilla`）
+
+**即時読み込み** — キーが `/` で終わらない: `"@components/my-button": "./my-button.js"`、`"@components/fancy-input|vanilla,input": "./fancy-input.js"`（extends 省略時はプロトタイプから自動検出）
+
+**コンポーネント要件**（vanilla ローダー）: `.js` 拡張子 + カスタム要素クラスを `default` export:
+
+```javascript
+// components/ui/button.js
+export default class UiButton extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' }).innerHTML = '<button><slot></slot></button>';
+  }
+}
+```
+
+- `is` 属性（拡張ビルトイン）も自動検出（autoloader が `{ extends }` 付きで define）。
+- ロード失敗コンポーネントは再試行されない（失敗検出は `@wcstack/defined` の領分）。MutationObserver で動的追加要素も検知。
+
+## 7. 実デモの index.html 全体構造（examples/router-spa 実物骨格）
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- ディープリンク必須: 無いと /products/3 直ロード時にそのパスが basename になる -->
+  <base href="/">
+  <title>wcstack: router + state + fetch demo</title>
+  <style>/* a.active でアクティブリンク装飾 */</style>
+  <script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+  <script type="module" src="https://esm.run/@wcstack/fetch/auto"></script>
+  <script type="module" src="https://esm.run/@wcstack/router/auto"></script>
+</head>
+<body>
+
+<nav aria-label="Main">
+  <wcs-link to="/">Products</wcs-link>
+  <wcs-link to="/about">About</wcs-link>
+</nav>
+
+<wcs-state>
+  <script type="module">
+    export default {
+      path: "",
+      navigateUrl: null,
+      productsFetch: { value: null, loading: false, error: null, status: 0 },
+      productFetch: { value: null, loading: false, error: null, status: 0 },
+      get productId() {
+        const m = this.path.match(/^\/products\/(\d+)$/);
+        return m ? Number(m[1]) : null;
+      },
+      get isList() { return this.path === "/" || this.path === ""; },
+      get isDetail() { return this.productId !== null; },
+      get "productFetch.url"() {
+        return this.productId ? "/api/products/" + this.productId : undefined;
+      },
+      get products() { return this["productsFetch.value"] ?? []; },
+      openProduct() { this.navigateUrl = "/products/" + this["products.*.id"]; },
+      goToProducts() { this.navigateUrl = "/"; },
+    };
+  </script>
+</wcs-state>
+
+<!-- Router: URL・履歴・ページ <title>・静的ページを所有 -->
+<wcs-router data-wcs="path: path; navigateUrl: navigateUrl">
+  <template>
+    <wcs-route path="/">
+      <wcs-head><title>Products</title></wcs-head>
+    </wcs-route>
+    <wcs-route path="/products/:productId(int)">
+      <wcs-head><title>Product detail</title></wcs-head>
+    </wcs-route>
+    <wcs-route path="/about">
+      <wcs-head><title>About</title></wcs-head>
+      <section><!-- 静的コンテンツを直接記述（data-wcs なし） --></section>
+    </wcs-route>
+    <wcs-route fallback>
+      <wcs-head><title>Not found</title></wcs-head>
+      <section>
+        <h2>404</h2>
+        <p><wcs-link to="/">Back</wcs-link></p>
+      </section>
+    </wcs-route>
+  </template>
+</wcs-router>
+<wcs-outlet></wcs-outlet>
+
+<!-- ヘッドレス fetch ノード（spread で全出力を state スロットへ） -->
+<wcs-fetch url="/api/products" data-wcs="...: productsFetch"></wcs-fetch>
+<wcs-fetch data-wcs="...: productFetch"></wcs-fetch>
+
+<!-- データバインドされるページは state 管理の <template data-wcs="if:"> 配下（body 直下） -->
+<template data-wcs="if: isList">
+  <section aria-label="Product list">
+    <ul>
+      <template data-wcs="for: products">
+        <li>
+          <button type="button" data-wcs="onclick: openProduct; attr.aria-label: .name">
+            <span data-wcs="textContent: .name"></span>
+            <span>¥<span data-wcs="textContent: .price|locale('ja-JP')"></span></span>
+          </button>
+        </li>
+      </template>
+    </ul>
+  </section>
+</template>
+
+<template data-wcs="if: isDetail">
+  <section aria-label="Product detail">
+    <button type="button" data-wcs="onclick: goToProducts">&larr; Back</button>
+    <h2 data-wcs="textContent: productFetch.value.name"></h2>
+  </section>
+</template>
+
+</body>
+</html>
+```
+
+### サーバー側の SPA フォールバック（examples/router-spa/server.js 実物）
+
+```javascript
+// SPA fallback: 非 API・拡張子なし GET はすべて index.html を返す
+if (!url.pathname.startsWith("/api/") && extname(url.pathname) === "") {
+  const html = await readFile(join(__dirname, "index.html"));
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(html);
+  return true;
+}
+```
+
+## 8. 自作カスタム要素をルートに載せる作法
+
+- ルート内にタグを直接書き、パラメータは `data-bind`（§2）で受ける。
+- **define は router の責務外** — autoloader（§6）か手動 `customElements.define()` が別途必要。
+- 代替パターン（router-spa の実証）: カスタム要素を作らず、ルートには `<wcs-head>` + 静的コンテンツのみ置き、データバインドされるページ DOM は body 直下の `<template data-wcs="if: ...">` で `path` 由来の getter により切り替える（§9-3 の制約のため、このパターンが state 併用時の既定解）。
+
+## 9. 落とし穴チェックリスト
+
+1. **`<base href="/">` がないとディープリンクが壊れる**（basename が `document.baseURI` から誤導出される）。
+2. **サーバーに SPA フォールバックが必要** — 無いとリロード・直リンクが 404。
+3. **router がスタンプするノードに `data-wcs` を書いても state は監視しない** — state はバインド時点の DOM しか収集しない。データバインドは body 直下の `<template data-wcs="if:">` に置く。
+4. script の順序 — I/O ノード系を `@wcstack/state` より先に並べるのがベストプラクティス。
+5. Light DOM レイアウトでは `slot` 属性付き要素は `<wcs-layout>` の直接の子のみ有効。
+6. 型不一致はエラーでなく「マッチしない」— `/products/abc` は `:productId(int)` を素通りして fallback へ。
+7. トップレベルルートに相対パスは書けない。ネストルートは相対パス。
+8. `undefined` は要素に書き込まれない（write-skip）— getter が `undefined` を返すと `<wcs-fetch>` は沈黙。url 同値ガードで同一 URL は再フェッチしない。
+9. autoloader のロード失敗は再試行されない。

--- a/.claude/skills/wcstack-app/references/state-binding.md
+++ b/.claude/skills/wcstack-app/references/state-binding.md
@@ -1,0 +1,334 @@
+# @wcstack/state リファレンス
+
+出典: `packages/state/README.ja.md`（正本）・`packages/state/examples/*`・`packages/fetch/examples/users-crud`・`src/filters/builtinFilters.ts`・`src/bindTextParser/*`。すべて実コード確認済み。
+
+## 1. CDN 読み込み
+
+```html
+<!-- 自動初期化（examples 全実物で使用されている一行） -->
+<script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+```
+
+```html
+<!-- 手動初期化 -->
+<script type="module">
+  import { bootstrapState } from 'https://esm.run/@wcstack/state';
+  bootstrapState();
+</script>
+```
+
+## 2. `<wcs-state>` 状態定義（6方式）
+
+解決順序: `state` 属性 → `src`(.json/.js) → `json` 属性 → 内包 `<script>` → `setInitialState()` 待機。
+
+```html
+<!-- 1. <script type="application/json"> を id で参照 -->
+<script type="application/json" id="state">{ "count": 0 }</script>
+<wcs-state state="state"></wcs-state>
+
+<!-- 2. インライン JSON 属性 -->
+<wcs-state json='{ "count": 0 }'></wcs-state>
+
+<!-- 3. 外部 JSON -->
+<wcs-state src="./data.json"></wcs-state>
+
+<!-- 4. 外部 JS モジュール (export default {...}) -->
+<wcs-state src="./state.js"></wcs-state>
+
+<!-- 5. インラインスクリプト（最頻出。type="module" で export default） -->
+<wcs-state>
+  <script type="module">
+    export default { count: 0 };
+  </script>
+</wcs-state>
+
+<!-- 6. プログラム API -->
+<script>
+  const el = document.createElement('wcs-state');
+  el.setInitialState({ count: 0 });
+  document.body.appendChild(el);
+</script>
+```
+
+`<wcs-state>` の属性: `name`(状態名、デフォルト `"default"`) / `state` / `src` / `json` / `bind-component`(Web Component バインディング) / `enable-ssr`。
+
+### 名前付き状態
+
+```html
+<wcs-state name="cart">...</wcs-state>
+<div data-wcs="textContent: total@cart"></div>
+```
+
+## 3. `data-wcs` バインディング構文
+
+```
+property[#modifier[,modifier...]][|入力フィルタ...]: path[@state][|出力フィルタ...]
+```
+
+- 複数バインディングは **`;` 区切り**: `data-wcs="textContent: count; class.over: count|gt(10)"`
+- 左辺（プロパティ側）のフィルタは **DOM→state の入力方向**に適用: `<select data-wcs="value|number: selectedProductId">`
+- 右辺フィルタは state→DOM の出力方向。
+- 複数 modifier は `#` 1つの後にカンマ区切り: `value#ro,init=none: path`
+
+### プロパティ種別
+
+| プロパティ | 説明 |
+|---|---|
+| `value` | 要素の値（input/select/textarea で双方向） |
+| `checked` | checkbox/radio の選択状態（双方向） |
+| `textContent` / `text` | テキスト（`text` はエイリアス） |
+| `html` | innerHTML |
+| `class.NAME` | CSS クラスの on/off（真偽値で切替） |
+| `style.PROP` | CSS スタイルプロパティ |
+| `attr.NAME` | 属性設定（SVG 名前空間対応） |
+| `radio` | ラジオグループ→単一値（双方向） |
+| `checkbox` | チェックボックスグループ→配列（双方向） |
+| `onclick`, `on*` | イベントハンドラ |
+
+これに加え任意の DOM プロパティ名が使える（例: `disabled: createFetch.loading`）。
+
+### 修飾子
+
+| 修飾子 | 説明 |
+|---|---|
+| `#ro` | 読み取り専用（双方向を無効化） |
+| `#prevent` | `event.preventDefault()` |
+| `#stop` | `event.stopPropagation()` |
+| `#onchange` | 双方向バインディングを `input` でなく `change` イベントで |
+| `#init=state\|element\|auto\|none` | バインディング authority（wcBindable 要素向け初期同期の向き） |
+| `#sync=call\|connect` | element authority 時のスナップショット読み取りタイミング |
+
+### 双方向バインディング（自動有効）
+
+`<input>`(value/checked/valueAsNumber/valueAsDate)・`<select>`(value, change イベント)・`<textarea>`(value)。`<input type="button">` は除外。
+
+### Mustache 構文
+
+テキストノードで `{{ path|filter }}`（デフォルト有効）:
+
+```html
+<p>こんにちは、{{ user.name }}さん！</p>
+<p>カウント: {{ count|locale }}</p>
+```
+
+## 4. リスト描画（`for`）
+
+```html
+<template data-wcs="for: users">
+  <div>
+    <span data-wcs="textContent: users.*.name"></span>  <!-- フルパス -->
+    <span data-wcs="textContent: .name"></span>          <!-- ドット省略形 -->
+  </div>
+</template>
+```
+
+- キー属性不要（値ベース差分）。配列は**必ず新配列を再代入**（`concat`/`toSpliced`/`filter`/`toSorted`/`toReversed`/`with`）。`push`/`splice`/`sort` は検知されない。
+- ドット省略形: `.name` → `users.*.name`、`.` → `users.*`（プリミティブ配列の要素値）、`.name|uc`・`.name@state` も可。
+- Mustache 内でも `{{ .name }}` が使える。
+
+### ネストループ
+
+```html
+<template data-wcs="for: regions">
+  <template data-wcs="for: .states">        <!-- .states → regions.*.states -->
+    <span data-wcs="textContent: .name"></span> <!-- → regions.*.states.*.name -->
+  </template>
+</template>
+```
+
+### ループインデックス
+
+- getter/ハンドラ内: `this.$1`(外側)、`this.$2`(内側)…
+- テンプレート内: `{{ $1|inc(1) }}`（1始まり行番号）
+- `.length` パスも可: `data-wcs="if: cart.items.length|gt(0)"`
+
+## 5. 条件描画（`if` / `elseif` / `else`）
+
+```html
+<template data-wcs="if: count|gt(0)"><p>正</p></template>
+<template data-wcs="elseif: count|lt(0)"><p>負</p></template>
+<template data-wcs="else:"><p>ゼロ</p></template>
+```
+
+`else:` は**末尾コロン必須**（右辺なし）。`if` のネストも可。
+
+## 6. computed（パス getter）と Proxy API
+
+class 構文ではなく **plain object の getter**。ドットパス文字列キー + `*` ワイルドカード:
+
+```javascript
+export default {
+  users: [{ id: 1, firstName: "Alice", lastName: "Smith" }],
+  get total() { return this.price * (1 + this.tax); },          // トップレベル
+  get "cart.totalPrice"() { /* ネスト算出 */ },
+  get "users.*.fullName"() {                                     // ワイルドカード
+    return this["users.*.firstName"] + " " + this["users.*.lastName"];
+  },
+  set "users.*.fullName"(value) { /* パス setter、双方向対応 */ },
+  get "categories.*.items.*.label"() { /* 多重ワイルドカード */ },
+};
+```
+
+- getter 内の `this["users.*.firstName"]` は現在のループ要素に自動解決。依存自動追跡・アドレス単位キャッシュ。
+- 数値インデックス直接アクセス可: `this["users.0.name"]`、`` this[`cart.items.${i}.quantity`] += 1 ``。
+- getter の戻り値オブジェクトへのチェーン可: `this["cart.items.*.product.price"]`。
+
+### Proxy API（`this` 経由）
+
+| API | 説明 |
+|---|---|
+| `this.$getAll(path, indexes?)` | ワイルドカードパスの全値を配列で取得（集計用）。部分インデックス指定可: `this.$getAll("regions.*.states.*.population", [this.$1])` |
+| `this.$resolve(path, indexes, value?)` | 特定インデックスで読み書き |
+| `this.$postUpdate(path)` | 更新通知を手動発行 |
+| `this.$trackDependency(path)` / `this.$untrackDependency(fn)` | 依存の手動登録 / 抑止 |
+| `this.$stateElement` | IStateElement アクセス |
+| `this.$1`, `this.$2`, ... | ループインデックス |
+
+### 状態更新の鉄則
+
+```javascript
+this["user.name"] = "Bob";   // ✅ パスへの代入 → DOM 更新
+this.user.name = "Bob";      // ❌ 検知されない
+```
+
+## 7. フィルタ（組み込み40種で固定・カスタム登録 API なし）
+
+- 比較: `eq` `ne` `not` `lt` `le` `gt` `ge`
+- 算術: `inc` `dec` `mul` `div` `mod`
+- 数値フォーマット: `fix` `round` `floor` `ceil` `locale` `percent`
+- 文字列: `uc` `lc` `cap` `trim` `slice` `substr` `pad` `rep` `rev`
+- 型変換: `int` `float` `boolean` `number` `string` `null`
+- 日付: `date` `time` `datetime` `ymd`
+- 真偽/デフォルト: `truthy` `falsy` `defaults`
+
+引数付き: `gt(10)`、`substr(0,10)`、`pad(5,0)`、`locale(ja-JP)`、`ymd(/)`、`eq('admin')`（クォート可・bare も可・カンマ区切り）。チェーン: `price|mul(1.1)|round(2)|locale(ja-JP)`。組み込みで書けない変換は getter で行う。
+
+## 8. イベントハンドリング
+
+```html
+<button data-wcs="onclick: handleClick">クリック</button>
+<form data-wcs="onsubmit#prevent: handleSubmit">...</form>
+```
+
+```javascript
+export default {
+  items: ["A", "B", "C"],
+  handleClick(event) { /* this = 状態プロキシ */ },
+  removeItem(event, index) {        // ループ内なら (event, ...listIndexes)
+    this.items = this.items.toSpliced(index, 1);
+  }
+};
+```
+
+- シグネチャ: `(event, ...listIndexes)`。ループ内では内包インデックスが event の後ろに付く。
+- **`onclick:` はメソッド名バインドのみで引数を渡せない** — 引数違いはゼロ引数ラッパーメソッドを用意する（例: `filterAll() { this.filterBy(""); }`）。
+- 右辺に `$command.<name>` を書くと直接 emit: `<button data-wcs="onclick: $command.refreshList">`。
+
+## 9. command-token / event-token
+
+### command token（state → 要素メソッド起動）
+
+```html
+<wcs-state>
+  <script type="module">
+    export default {
+      $commandTokens: ["refreshList"],
+      onClick() { this.$command.refreshList.emit("/api/users", { method: "GET" }); }
+    };
+  </script>
+</wcs-state>
+<!-- 購読側。右辺は必ず $command.<name>（ベア名不可） -->
+<wcs-fetch data-wcs="command.fetch: $command.refreshList"></wcs-fetch>
+```
+
+- `$commandTokens: string[]` で宣言 → `this.$command.<name>.emit(...args)`。引数は購読要素のメソッドへそのまま転送（await されない。Promise は `Promise.all(token.emit(...))` で待つ）。
+- 1 token → 複数要素にファンアウト、subscribe 順保持。
+
+### event token（要素 → state）
+
+```html
+<wcs-state>
+  <script type="module">
+    export default {
+      users: [],
+      $eventTokens: ["userCreated"],
+      $on: {
+        userCreated(state, event) {          // this でなく第1引数 state
+          state.users = state.users.concat(event.detail);
+        },
+        // ループ内 emitter: (state, event, ...listIndexes)
+      }
+    };
+  </script>
+</wcs-state>
+<!-- キーは wcBindable プロパティ名（生イベント名ではない）。token 名はベア名（$ なし） -->
+<my-form data-wcs="eventToken.created: userCreated"></my-form>
+```
+
+### state ↔ wcs-fetch 実戦例（users-crud example の骨子）
+
+```html
+<script type="module" src="https://esm.run/@wcstack/fetch/auto"></script>
+<script type="module" src="https://esm.run/@wcstack/state/auto"></script>
+
+<wcs-state>
+  <script type="module">
+    export default {
+      $commandTokens: ["refreshList"],
+      $eventTokens: ["userResponded"],
+      // 1 fetch = 1 state slot。outputs は要素が authority なので実初期値(null)でシード
+      listFetch: { value: null, loading: false, error: null, status: 0 },
+      createFetch: { url: "/api/users", method: "POST", manual: true,
+                     body: { name: "" }, value: null, error: null, loading: false, status: 0 },
+      get "listFetch.url"() { return "/api/users"; },   // slot 内ネスト getter で URL を算出
+      get listRows() { return this["listFetch.value"] ?? []; }, // for: は配列必須なので null ガード
+      $on: {
+        userResponded: (state, event) => {
+          const status = event.detail?.status ?? 0;
+          if (status < 200 || status >= 300) return;   // wcs-fetch:response はエラー時も発火
+          state.$command.refreshList.emit();
+        },
+      },
+    };
+  </script>
+</wcs-state>
+
+<wcs-fetch data-wcs="...: listFetch; command.fetch: $command.refreshList"></wcs-fetch>
+<wcs-fetch data-wcs="...: createFetch; eventToken.value: userResponded">
+  <wcs-fetch-header name="Content-Type" value="application/json"></wcs-fetch-header>
+</wcs-fetch>
+```
+
+### spread バインディング（`...`）
+
+- `...: target` で wcBindable の properties + inputs を一括配線。`commands`/event token は対象外（明示配線必須）。
+- for 内: `...: storesFetches.*`（推奨）または `...: .`。
+- 後勝ち上書き: `...: usersFetch; status: alternateStatus`。
+- 右辺フィルタは**エラー**。`@stateName` は伝播。wcBindable 未宣言要素は**エラー**。
+- `undefined` の state パスはプロパティ書き込みスキップ（要素既定値が生きる）。クリアは `null` 代入。
+
+## 10. その他の機能
+
+- **ライフサイクル**: 状態オブジェクトに `$connectedCallback`(async 可・await される・再接続毎)、`$disconnectedCallback`(同期のみ)、`$updatedCallback(paths, indexesListByPath)`(async 可・await されない)。Web Component 側は `async $stateReadyCallback(stateProp)`。
+- **$streams**: `$streams: { name: { args?, source, fold?, initial? } }` — source は `(args, signal) => AsyncIterable|ReadableStream|Promise<同>`、AbortSignal 尊重必須、`fold` 指定時 `initial` 必須。status/error は `$streamStatus.<name>`(`"idle"|"active"|"done"|"error"`) / `$streamError.<name>`。args は同期・wildcard 読み不可・自己依存禁止。無限ストリームは有界 fold 必須。
+- **Web Component**: shadowRoot 内に `<wcs-state bind-component="state">`、ホストから `data-wcs="state.message: user.name"`。Light DOM では `name` 属性必須 + `@name` 参照必須（無いと名前空間衝突）。
+- **DCC**: `<my-counter data-wc-definition><template shadowrootmode="open">...<wcs-state>...` + `$bindables: ["count"]` で JS クラス無しのカスタム要素定義。
+- **設定**: `bootstrapState({ locale, debug, enableMustache, bindAttributeName, tagNames: { state }, enableDirectionalInitialSync, enablePropagationContext, enableContractAnalyzer })`。
+- **TypeScript**: `defineState({...})` ラップで `this` 型補完（ランタイムコストゼロ）。
+- **SSR**: `<wcs-state enable-ssr>` + `@wcstack/server` の `renderToString()`。
+
+## 落とし穴チェックリスト
+
+1. `this.user.name = "Bob"` は検知されない — 必ず `this["user.name"] = "Bob"`。
+2. `push`/`splice`/`sort` 等の破壊的メソッドは検知されない — 新配列を再代入。
+3. `onclick:` に引数は渡せない — ゼロ引数ラッパーメソッドで対応。
+4. `for:` のパスは配列必須 — fetch の `value` が null の間は `?? []` の派生 getter を挟む。
+5. command binding 右辺のベア名（`fetchUsers`）は不可 — `$command.fetchUsers` 必須。
+6. `eventToken.` のキーは生 DOM イベント名でなく wcBindable **プロパティ名**。
+7. `wcs-fetch:response`（value イベント）は HTTP/ネットワークエラー時も発火 — `$on` で status を確認。
+8. output-only な wcBindable メンバに都合のよい初期値をシードしない（要素側実初期値が置き換える）。
+9. `$streams` の source は AbortSignal 無視禁止。
+10. `else:` の末尾コロンを忘れない。
+11. `$commandTokens`/`$eventTokens` の重複エントリ・`$on` の未宣言キーは初期化時エラー。未宣言 token へのアクセス（`this.$command.typo`）は `undefined`。
+12. カスタムフィルタ登録 API は存在しない — 組み込み 40 種で書けない変換は getter で行う。
+13. `data-wcs` の複数バインディング区切りは `;` のみを正とする。


### PR DESCRIPTION
Add a Claude Code skill that teaches AI agents to build wcstack apps with accurate syntax: SKILL.md (workflow + invariants + minimal template) plus three references extracted from package READMEs, examples, and wcBindable declarations (data-wcs binding syntax, router/autoloader scaffolding, I/O node catalog + signals cheat sheet).